### PR TITLE
Draft: Refactor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,42 +35,45 @@ import numpy as np
 from sklearn.datasets import load_diabetes
 
 X, y = load_diabetes(return_X_y=True)
-X = np.hstack((np.ones((X.shape[0], 1)), X))
+
+# Model coefficients 
+equation = {
+    0 : "all", # Can also use "intercept" or np.ndarray of integers / booleans
+    1 : "all", 
+    2 : "all", 
+}
 
 # Create the estimator
 online_gamlss_lasso = rolch.OnlineGamlss(
-    distribution=rolch.DistributionT(), 
-    method="lasso"
+    distribution=rolch.DistributionT(),
+    method="lasso",
+    equation=equation,
+    estimation_kwargs={"ic": {i: "bic" for i in range(dist.n_params)}},
 )
 
 # Initial Fit
 online_gamlss_lasso.fit(
-    y[:-11], 
-    X[:-11, :], 
-    X[:-11, :], 
-    X[:-11, :]
+    X=X[:-11, :], 
+    y=y[:-11], 
 )
 print("Coefficients for the first N-11 observations \n")
-print(np.vstack(online_gamlss_lasso.betas).T)
+print(online_gamlss_lasso.betas)
 
 # Update call
 online_gamlss_lasso.update(
-    y[[-11]], 
-    X[[-11], :], 
-    X[[-11], :], 
-    X[[-11], :]
+    X=X[[-11], :], 
+    y=y[[-11]]
 )
 print("\nCoefficients after update call \n")
-print(np.vstack(online_gamlss_lasso.betas).T)
+print(online_gamlss_lasso.betas)
 
 # Prediction for the last 10 observations
 prediction = online_gamlss_lasso.predict(
-    X[-10:, :], 
-    X[-10:, :], 
-    X[-10:, :]
+    X=X[-10:, :]
 )
 
 print("\n Predictions for the last 10 observations")
+# Location, scale and shape (degrees of freedom)
 print(prediction)
 ```
 
@@ -105,4 +108,4 @@ To get started, just create a fork and get going. We will modularize the code ov
 2) Install the necessary dependencies from the `requirements.txt` using `conda create --name <env> --file requirements.txt`. 
 3) Run `python3 -m build` to build the wheel.
 4) Run `pip install dist/rolch-0.1.0-py3-none-any.whl` with the accurate version. If necessary, append `--force-reinstall`
-5) Enjoy.
+5) Enjoy.O

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ online_gamlss_lasso = rolch.OnlineGamlss(
     distribution=rolch.DistributionT(),
     method="lasso",
     equation=equation,
+    fit_intercept=True,
     estimation_kwargs={"ic": {i: "bic" for i in range(dist.n_params)}},
 )
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Welcome to `ROLCH`
+# Welcome to `ROLCH` - Regularized Online Learning for Conditional Heteroskedasticity
 
 `ROLCH` is a `Python` package for online distributional learning and online models for conditionally heteroskedastic data. We provide an online implementation of the well-known GAMLSS model using online coordinate descent (OCD).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,26 @@
 !!! note
     `ROLCH` is currently in the first alpha phase. Please expect changes to happen frequently.
 
+## Introduction
+
+This package provides an online estimation of models for distributional regression, respectively, models for conditional heteroskedastic data. The main contribution is an online/incremental implementation of the generalized additive models for location, shape and scale (GAMLSS, see [Rigby & Stasinopoulos, 2005](https://academic.oup.com/jrsssc/article-abstract/54/3/507/7113027)) developed in [Hirsch, Berrisch & Ziel, 2024](https://arxiv.org/abs/2407.08750).
+
+Please have a look at the [documentation](https://simon-hirsch.github.io/rolch/) or the [example notebook](https://github.com/simon-hirsch/rolch/blob/main/example.ipynb).
+
+We're actively working on the package and welcome contributions from the community. Have a look at the [Release Notes](https://github.com/simon-hirsch/rolch/releases) and the [Issue Tracker](https://github.com/simon-hirsch/rolch/issues).
+
+## Distributional Regression
+
+The main idea of distributional regression (or regression beyond the mean, multiparameter regression) is that the response variable $Y$ is distributed according to a specified distribution $\mathcal{F}(\theta)$, where $\theta$ is the parameter vector for the distribution. In the Gaussian case, we have $\theta = (\theta_1, \theta_2) = (\mu, \sigma)$. We then specify an individual regression model for all parameters of the distribution of the form 
+
+$$g_k(\theta_k) = \eta_k = X_k\beta_k$$
+
+where $g_k(\cdot)$ is a link function, which ensures that the predicted distribution parameters are in a sensible range (we don't want, e.g. negative standard deviations), and $\eta_k$ is the predictor. For the Gaussian case, this would imply that we have two regression equations, one for the mean (location) and one for the standard deviation (scale) parameters. Distributions other than the normal distribution are possible, and we have already implemented them, e.g., Student's $ t$ distribution and Johnson's $S_U$ distribution. If you are interested in another distribution, please open an Issue.
+
+This allows us to specify very flexible models that consider the conditional behaviour of the variable's volatility, skewness and tail behaviour. A simple example for electricity markets is wind forecasts, which are skewed depending on the production level - intuitively, there is a higher risk of having lower production if the production level is already high since it cannot go much higher than "full load" and if, the turbines might cut-off. Modelling these conditional probabilistic behaviours is the key strength of distributional regression models.
+
+
+
 ## Installation
 
 `ROLCH` is available on the [Python Package Index](https://pypi.org/project/rolch/) and can be installed via `pip`:

--- a/example.ipynb
+++ b/example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 11,
    "id": "e37ae52f-fa91-4128-9580-d12c61984cc7",
    "metadata": {},
    "outputs": [
@@ -19,6 +19,7 @@
     "import numpy as np\n",
     "from sklearn.datasets import load_diabetes, make_regression\n",
     "import matplotlib.pyplot as plt\n",
+    "from pprint import pprint\n",
     "\n",
     "np.set_printoptions(precision=3, suppress=True)\n",
     "print(rolch.__version__)"
@@ -34,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 12,
    "id": "1fd422ca-82aa-44d2-8287-5bfcae8c6d4e",
    "metadata": {},
    "outputs": [],
@@ -42,8 +43,7 @@
     "## Diabetes data set\n",
     "## Add intercept (will not be regularized)\n",
     "\n",
-    "X, y = load_diabetes(return_X_y=True)\n",
-    "X = np.hstack((np.ones((X.shape[0], 1)), X))"
+    "X, y = load_diabetes(return_X_y=True)"
    ]
   },
   {
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 13,
    "id": "558ca51e-a311-4d4b-87b5-17986b364ed3",
    "metadata": {},
    "outputs": [
@@ -66,29 +66,30 @@
      "text": [
       "OLS Coefficients \n",
       "\n",
-      "[[151.647   3.94 ]\n",
-      " [  0.576  -0.066]\n",
-      " [-11.585  -0.114]\n",
-      " [ 22.359   0.046]\n",
-      " [ 16.478   0.108]\n",
-      " [-25.09   -0.41 ]\n",
-      " [ 12.188   0.429]\n",
-      " [ -0.676  -0.073]\n",
-      " [  6.9    -0.172]\n",
-      " [ 30.304   0.206]\n",
-      " [  2.88    0.057]]\n"
+      "{0: array([152.004,  -0.621, -12.37 ,  23.288,  15.373, -28.417,  15.796,\n",
+      "        -0.309,   6.318,  33.086,   2.393]),\n",
+      " 1: array([ 3.986, -0.031, -0.02 ,  0.067,  0.045,  0.048, -0.084,  0.007,\n",
+      "        0.043, -0.024,  0.036])}\n"
      ]
     }
    ],
    "source": [
+    "equation = {\n",
+    "    0: \"all\",\n",
+    "    1: \"all\",\n",
+    "}\n",
+    "\n",
     "online_gamlss_ols = rolch.OnlineGamlss(\n",
-    "    distribution=rolch.DistributionNormal(), method=\"ols\", rss_tol_inner=np.inf\n",
+    "    distribution=rolch.DistributionNormal(),\n",
+    "    method=\"ols\",\n",
+    "    equation=equation,\n",
+    "    fit_intercept=True,\n",
     ")\n",
     "\n",
-    "online_gamlss_ols.fit(y, X, X)\n",
+    "online_gamlss_ols.fit(X, y)\n",
     "\n",
     "print(\"OLS Coefficients \\n\")\n",
-    "print(np.vstack(online_gamlss_ols.betas).T)"
+    "pprint(online_gamlss_ols.betas)"
    ]
   },
   {
@@ -101,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 14,
    "id": "2d8d950d-3749-4c86-8f05-8082b9e25ae4",
    "metadata": {},
    "outputs": [
@@ -127,10 +128,17 @@
    ],
    "source": [
     "dist = rolch.DistributionT()\n",
+    "equation = {\n",
+    "    0: \"all\",  # Can also use: \"intercept\" or pass a numpy array with indices / boolean\n",
+    "    1: \"all\",\n",
+    "    2: \"all\",\n",
+    "}\n",
     "\n",
     "online_gamlss_lasso = rolch.OnlineGamlss(\n",
     "    distribution=dist,\n",
     "    method=\"lasso\",\n",
+    "    equation=equation,\n",
+    "    fit_intercept=True,\n",
     "    estimation_kwargs={\n",
     "        \"ic\": {i: \"bic\" for i in range(dist.n_params)},  # Change the IC if you like\n",
     "        \"lambda_eps\": {\n",
@@ -139,10 +147,10 @@
     "    },\n",
     "    rss_tol_inner=np.inf,\n",
     ")\n",
-    "online_gamlss_lasso.fit(y, X, X, X)\n",
+    "online_gamlss_lasso.fit(X, y)\n",
     "\n",
     "print(\"LASSO Coefficients \\n\")\n",
-    "print(np.vstack(online_gamlss_lasso.betas).T)"
+    "print(np.vstack([*online_gamlss_lasso.betas.values()]).T)"
    ]
   },
   {
@@ -155,7 +163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 15,
    "id": "7e8a74f8-f170-440e-a27f-fa3a14c0b924",
    "metadata": {},
    "outputs": [
@@ -180,21 +188,22 @@
     }
    ],
    "source": [
+    "# Fit for all until the last observation\n",
     "online_gamlss_lasso = rolch.OnlineGamlss(\n",
     "    distribution=rolch.DistributionT(),\n",
     "    method=\"lasso\",\n",
+    "    equation=equation,\n",
     "    estimation_kwargs={\"ic\": {i: \"bic\" for i in range(dist.n_params)}},\n",
     ")\n",
-    "\n",
-    "online_gamlss_lasso.fit(y[:-1], X[:-1, :], X[:-1, :], X[:-1, :])\n",
+    "online_gamlss_lasso.fit(X=X[:-1, :], y=y[:-1])\n",
     "\n",
     "print(\"Coefficients for the first N-1 observations \\n\")\n",
-    "print(np.vstack(online_gamlss_lasso.betas).T)"
+    "print(np.vstack([*online_gamlss_lasso.betas.values()]).T)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 16,
    "id": "3a3740ca-2c78-427a-b1d1-b4e2a5abcdd7",
    "metadata": {},
    "outputs": [
@@ -220,10 +229,10 @@
     }
    ],
    "source": [
-    "online_gamlss_lasso.update(y[[-1]], X[[-1], :], X[[-1], :], X[[-1], :])\n",
+    "online_gamlss_lasso.update(X[[-1], :], y[[-1]])\n",
     "\n",
     "print(\"\\nCoefficients after update call \\n\")\n",
-    "print(np.vstack(online_gamlss_lasso.betas).T)"
+    "print(np.vstack([*online_gamlss_lasso.betas.values()]).T)"
    ]
   }
  ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,11 @@ dependencies=[
     "numba >= 0.59.1, < 1.0.0"
 ]
 
+[project.optional-dependencies]
+pandas = ["pandas >= 1.26"]
+polars = ["polars"]
+all = ["rolch[pandas, polars]"]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/rolch/__init__.py
+++ b/src/rolch/__init__.py
@@ -1,3 +1,5 @@
+# ruff: noqa: E402
+
 from importlib.metadata import version
 from importlib.util import find_spec
 

--- a/src/rolch/__init__.py
+++ b/src/rolch/__init__.py
@@ -1,16 +1,5 @@
-HAS_PANDAS = False
-HAS_POLARS = False
-
 from importlib.metadata import version
 from importlib.util import find_spec
-
-if find_spec("pandas") is not None:
-    HAS_PANDAS = True
-    import pandas as pd
-
-if find_spec("polars") is not None:
-    HAS_POLARS = True
-    import polars as pl
 
 from rolch.coordinate_descent import (
     online_coordinate_descent,
@@ -53,6 +42,15 @@ from rolch.utils import (
     calculate_asymptotic_training_length,
     calculate_effective_training_length,
 )
+
+HAS_PANDAS = False
+HAS_POLARS = False
+
+if find_spec("pandas") is not None:
+    HAS_PANDAS = True
+
+if find_spec("polars") is not None:
+    HAS_POLARS = True
 
 __version__ = version("rolch")
 

--- a/src/rolch/__init__.py
+++ b/src/rolch/__init__.py
@@ -1,6 +1,15 @@
 from importlib.metadata import version
 from importlib.util import find_spec
 
+HAS_PANDAS = False
+HAS_POLARS = False
+
+if find_spec("pandas") is not None:
+    HAS_PANDAS = True
+
+if find_spec("polars") is not None:
+    HAS_POLARS = True
+
 from rolch.coordinate_descent import (
     online_coordinate_descent,
     online_coordinate_descent_path,
@@ -42,15 +51,6 @@ from rolch.utils import (
     calculate_asymptotic_training_length,
     calculate_effective_training_length,
 )
-
-HAS_PANDAS = False
-HAS_POLARS = False
-
-if find_spec("pandas") is not None:
-    HAS_PANDAS = True
-
-if find_spec("polars") is not None:
-    HAS_POLARS = True
 
 __version__ = version("rolch")
 

--- a/src/rolch/__init__.py
+++ b/src/rolch/__init__.py
@@ -1,4 +1,16 @@
+HAS_PANDAS = False
+HAS_POLARS = False
+
 from importlib.metadata import version
+from importlib.util import find_spec
+
+if find_spec("pandas") is not None:
+    HAS_PANDAS = True
+    import pandas as pd
+
+if find_spec("polars") is not None:
+    HAS_POLARS = True
+    import polars as pl
 
 from rolch.coordinate_descent import (
     online_coordinate_descent,

--- a/src/rolch/abc.py
+++ b/src/rolch/abc.py
@@ -1,7 +1,19 @@
+import warnings
 from abc import ABC, abstractmethod
-from typing import Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import numpy as np
+
+from rolch import HAS_PANDAS, HAS_POLARS
+from rolch.gram import (
+    init_gram,
+    init_inverted_gram,
+    init_y_gram,
+    update_gram,
+    update_inverted_gram,
+    update_y_gram,
+)
+from rolch.utils import handle_param_dict
 
 
 class LinkFunction(ABC):
@@ -73,3 +85,195 @@ class Distribution(ABC):
     @abstractmethod
     def rvs(self, size: Union[int, Tuple], theta: np.ndarray) -> np.ndarray:
         """Draw random samples of shape size."""
+
+
+class Estimator(ABC):
+    """
+    Base class for estimators.
+    """
+
+    def __init__(
+        self,
+        distribution: Distribution,
+        equation: Optional[Dict] = None,
+        fit_intercept: Union[bool, Dict] = True,
+        method: Union[str, Dict] = "lasso",
+        forget: float = 0.0,
+    ):
+        self.method = method
+        self.forget = forget
+        self.distribution = distribution
+        self.fit_intercept = fit_intercept
+        self.equation = self.preprocess_equation(equation)
+
+    def preprocess_equation(self, equation):
+        if equation is None:
+            warnings.warn(
+                "Equation is not specified. "
+                "Per default, will estimate the first distribution parameter by all covariates found in X. "
+                "All other distribution parameters will be estimated by an intercept."
+            )
+            equation = {
+                p: "all" if p == 0 else "intercept"
+                for p in range(self.distribution.n_params)
+            }
+        else:
+            for p in range(self.distribution.n_params):
+                # Check that all distribution parameters are in the equation.
+                # If not, add intercept.
+                if p not in equation.keys():
+                    warnings.warn(
+                        f"Distribution parameter {p} is not in equation. "
+                        f"The parameter will be estimated by an intercept."
+                    )
+                    equation[p] = "intercept"
+
+                if not (
+                    isinstance(equation[p], np.ndarray)
+                    or (equation[p] in ["all", "intercept"])
+                ):
+                    if not (
+                        isinstance(equation[p], list) and (HAS_PANDAS | HAS_POLARS)
+                    ):
+                        raise ValueError(
+                            "The equation should contain of either: \n"
+                            " - a numpy array of dtype int, \n"
+                            " - a list of string column names \n"
+                            " - or the strings 'all' or 'intercept' \n"
+                            f"you have passed {equation[p]} for the distribution parameter {p}."
+                        )
+
+        return equation
+
+    def make_model_array(self, X: Union[np.ndarray], param: int):
+        eq = self.equation[param]
+
+        # TODO: Add intercept here?
+        # TODO: Check difference between np.array and list more explicitly?
+        if eq == "all":
+            if isinstance(X, np.ndarray):
+                return X
+            if HAS_PANDAS and isinstance(X, pd.DataFrame):
+                return X.to_numpy()
+            if HAS_POLARS and isinstance(X, pl.DataFrame):
+                return X.to_numpy()
+        elif eq == "intercept":
+            return np.ones((X.shape[0], 1))
+        elif isinstance(eq, np.ndarray) | isinstance(eq, list):
+            if isinstance(X, np.ndarray):
+                return X[:, eq]
+            if HAS_PANDAS and isinstance(pd.DataFrame):
+                return X.loc[:, eq]
+            if HAS_POLARS and isinstance(pl.DataFrame):
+                return X.select(eq).to_numpy()
+
+    def make_gram(self, x: np.ndarray, w: np.ndarray, param: int) -> np.ndarray:
+        """
+        Make the Gram matrix.
+
+        Args:
+            x (np.ndarray): Covariate matrix.
+            w (np.ndarray): Weight matrix.
+            param (int): Parameter index.
+
+        Returns:
+            np.ndarray: Gram matrix.
+        """
+        if self.method[param] == "ols":
+            return init_inverted_gram(X=x, w=w, forget=self.forget[param])
+        elif self.method[param] == "lasso":
+            return init_gram(X=x, w=w, forget=self.forget[param])
+
+    def make_y_gram(
+        self, x: np.ndarray, y: np.ndarray, w: np.ndarray, param: int
+    ) -> np.ndarray:
+        """
+        Make the Gram matrix for the response variable.
+
+        Args:
+            x (np.ndarray): Covariate matrix.
+            y (np.ndarray): Response variable.
+            w (np.ndarray): Weight matrix.
+            param (int): Parameter index.
+
+        Returns:
+            np.ndarray: Gram matrix for the response variable.
+        """
+        return init_y_gram(X=x, y=y, w=w, forget=self.forget[param])
+
+    def update_gram(
+        self, gram: np.ndarray, x: np.ndarray, w: np.ndarray, param: int
+    ) -> np.ndarray:
+        """
+        Update the Gram matrix.
+
+        Args:
+            gram (np.ndarray): Current Gram matrix.
+            x (np.ndarray): Covariate matrix.
+            w (np.ndarray): Weight matrix.
+            param (int): Parameter index.
+
+        Returns:
+            np.ndarray: Updated Gram matrix.
+        """
+        if self.method[param] == "ols":
+            return update_inverted_gram(gram, X=x, w=w, forget=self.forget[param])
+        if self.method[param] == "lasso":
+            return update_gram(gram, X=x, w=w, forget=self.forget[param])
+
+    def update_y_gram(
+        self, gram: np.ndarray, x: np.ndarray, y: np.ndarray, w: np.ndarray, param: int
+    ) -> np.ndarray:
+        """
+        Update the Gram matrix for the response variable.
+
+        Args:
+            gram (np.ndarray): Current Gram matrix for the response variable.
+            x (np.ndarray): Covariate matrix.
+            y (np.ndarray): Response variable.
+            w (np.ndarray): Weight matrix.
+            param (int): Parameter index.
+
+        Returns:
+            np.ndarray: Updated Gram matrix for the response variable.
+        """
+        return update_y_gram(gram, X=x, y=y, w=w, forget=self.forget[param])
+
+    @staticmethod
+    def _make_intercept(n_observations: int) -> np.ndarray:
+        """Make the intercept series as N x 1 array.
+
+        Args:
+            y (np.ndarray): Response variable $Y$
+
+        Returns:
+            np.ndarray: Intercept array.
+        """
+        return np.ones((n_observations, 1))
+
+    @staticmethod
+    def _add_lags(
+        y: np.ndarray, x: np.ndarray, lags: Union[int, np.ndarray]
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Add lagged variables to the response and covariate matrices.
+
+        Args:
+            y (np.ndarray): Response variable.
+            x (np.ndarray): Covariate matrix.
+            lags (Union[int, np.ndarray]): Number of lags to add.
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: Tuple containing the updated response and covariate matrices.
+        """
+        if lags == 0:
+            return y, x
+
+        if isinstance(lags, int):
+            lags = np.arange(1, lags + 1, dtype=int)
+
+        max_lag = np.max(lags)
+        lagged = np.stack([np.roll(y, i) for i in lags], axis=1)[max_lag:, :]
+        new_x = np.hstack((x, lagged))[max_lag:, :]
+        new_y = y[max_lag:]
+        return new_y, new_x

--- a/src/rolch/coordinate_descent.py
+++ b/src/rolch/coordinate_descent.py
@@ -1,4 +1,4 @@
-from typing import Literal, Tuple, Union
+from typing import Literal, Tuple
 
 import numba as nb
 import numpy as np

--- a/src/rolch/online_gamlss.py
+++ b/src/rolch/online_gamlss.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Tuple, Union
 
 import numpy as np
 
-from rolch.abc import Distribution
+from rolch.abc import Distribution, Estimator
 from rolch.coordinate_descent import (
     DEFAULT_ESTIMATOR_KWARGS,
     online_coordinate_descent,
@@ -26,7 +26,7 @@ from rolch.utils import (
 )
 
 
-class OnlineGamlss:
+class OnlineGamlss(Estimator):
     """The online/incremental GAMLSS class."""
 
     def __init__(

--- a/src/rolch/online_gamlss.py
+++ b/src/rolch/online_gamlss.py
@@ -305,7 +305,7 @@ class OnlineGamlss(Estimator):
         self,
         X: np.ndarray,
         y: np.ndarray,
-        sample_weights: Optional[np.ndarray] = None,
+        sample_weight: Optional[np.ndarray] = None,
     ):
         """Fit the online GAMLSS model.
 
@@ -318,7 +318,7 @@ class OnlineGamlss(Estimator):
         Args:
             X (np.ndarray): Data Matrix. Currently supporting only numpy, will support pandas and polars in the future.
             y (np.ndarray): Response variable $Y$.
-            sample_weights (Optional[np.ndarray], optional): User-defined sample weights. Defaults to None.
+            sample_weight (Optional[np.ndarray], optional): User-defined sample weights. Defaults to None.
             beta_bounds (Dict[int, Tuple], optional): Bounds for the $\beta$ in the coordinate descent algorithm. The user needs to provide a `dict` with a mapping of tuples to distribution parameters 0, 1, 2, and 3 potentially. Defaults to None.
         """
         self.n_obs = y.shape[0]
@@ -327,8 +327,8 @@ class OnlineGamlss(Estimator):
             for p in range(self.distribution.n_params)
         }
 
-        if sample_weights is not None:
-            w = sample_weights  # Align to sklearn API
+        if sample_weight is not None:
+            w = sample_weight  # Align to sklearn API
         else:
             w = np.ones(y.shape[0])
 
@@ -423,7 +423,7 @@ class OnlineGamlss(Estimator):
         self,
         X: np.ndarray,
         y: np.ndarray,
-        sample_weights: Optional[np.ndarray] = None,
+        sample_weight: Optional[np.ndarray] = None,
     ):
         """Update the fit for the online GAMLSS Model.
 
@@ -436,10 +436,10 @@ class OnlineGamlss(Estimator):
         Args:
             X (np.ndarray): Data Matrix. Currently supporting only numpy, will support and pandas in the future.
             y (np.ndarray): Response variable $Y$.
-            sample_weights (Optional[np.ndarray], optional): User-defined sample weights. Defaults to None.
+            sample_weight (Optional[np.ndarray], optional): User-defined sample weights. Defaults to None.
         """
-        if sample_weights is not None:
-            w = sample_weights  # Align to sklearn API
+        if sample_weight is not None:
+            w = sample_weight  # Align to sklearn API
         else:
             w = np.ones(y.shape[0])
 

--- a/src/rolch/online_gamlss.py
+++ b/src/rolch/online_gamlss.py
@@ -372,11 +372,11 @@ class OnlineGamlss(Estimator):
                 )
 
         if self.method == "lasso":
-            for param in range(self.distribution.n_params):
-                is_regularized = np.repeat(True, self.J[param])
+            for p in range(self.distribution.n_params):
+                is_regularized = np.repeat(True, self.J[p])
                 if self.fit_intercept[p]:
                     is_regularized[0] = False
-                self.is_regularized[param] = is_regularized
+                self.is_regularized[p] = is_regularized
 
         self.beta_iterations = {i: {} for i in range(self.distribution.n_params)}
         self.beta_path_iterations = {i: {} for i in range(self.distribution.n_params)}

--- a/src/rolch/online_gamlss.py
+++ b/src/rolch/online_gamlss.py
@@ -52,10 +52,9 @@ class OnlineGamlss(Estimator):
 
         Args:
             distribution (rolch.Distribution): The parametric distribution
-            equation (Dict): The modelling equation. Follows the schema {parameter[int]: column_identifier}, where column_identifier can be either the strings 'all', 'intercept' or a np.array of ints indicating the columns.
+            equation (Dict): The modelling equation. Follows the schema `{parameter[int]: column_identifier}`, where column_identifier can be either the strings `'all'`, `'intercept'` or a np.array of ints indicating the columns.
             forget (float, optional): The forget factor. Defaults to 0.0.
-            method (str, optional): The estimation method. Defaults to "ols".
-
+            method (str, optional): The estimation method. Defaults to `"ols"`.
             scale_inputs (Optional[Dict], optional): Whether to scale the input matrices. Defaults to True
             beta_bounds (Dict[int, Tuple]): Dictionary of bounds for the different parameters.
             estimation_kwargs (Optional[Dict], optional): Dictionary of estimation method kwargs. Defaults to None.
@@ -888,7 +887,7 @@ class OnlineGamlss(Estimator):
 
         Args:
             X (np.ndarray): Design matrix.
-            what (str, optional): Predict the response or the link. Defaults to "response".
+            what (str, optional): Predict the response or the link. Defaults to "response". Remember the  GAMLSS models $g(\\theta) = X^T\\beta$. Predict `"link"` will output $X^T\\beta$, predict `"response"` will output $g^{-1}(X^T\\beta)$. Usually, you want predict = `"response"`.
             return_contributions (bool, optional): Whether to return a `Tuple[prediction, contributions]` where the contributions of the individual covariates for each distribution parameter's predicted value is specified. Defaults to False.
 
         Raises:

--- a/src/rolch/online_gamlss.py
+++ b/src/rolch/online_gamlss.py
@@ -1,8 +1,10 @@
 import copy
+import warnings
 from typing import Dict, Optional, Tuple, Union
 
 import numpy as np
 
+from rolch.abc import Distribution
 from rolch.coordinate_descent import (
     DEFAULT_ESTIMATOR_KWARGS,
     online_coordinate_descent,
@@ -29,11 +31,14 @@ class OnlineGamlss:
 
     def __init__(
         self,
-        distribution,
+        distribution: Distribution,
+        equation: Dict,
         forget: float = 0.0,
         method: str = "ols",
-        do_scale: Union[Dict, bool] = True,
-        expect_intercept: Union[Dict, bool] = True,
+        scale_inputs: bool = True,
+        fit_intercept: Union[bool, Dict] = True,
+        # Less important parameters
+        beta_bounds: Dict[int, Tuple] = None,
         estimation_kwargs: Optional[Dict] = None,
         max_it_outer: int = 30,
         max_it_inner: int = 30,
@@ -47,9 +52,12 @@ class OnlineGamlss:
 
         Args:
             distribution (rolch.Distribution): The parametric distribution
+            equation (Dict): The modelling equation. Follows the schema {parameter[int]: column_identifier}, where column_identifier can be either the strings 'all', 'intercept' or a np.array of ints indicating the columns.
             forget (float, optional): The forget factor. Defaults to 0.0.
             method (str, optional): The estimation method. Defaults to "ols".
-            do_scale (Optional[Dict], optional): Whether to scale the input matrices. Defaults to None, which implies that all inputs will be scaled. Note that the scaler assumes that the first column of each $X$ contains the intercept.
+
+            scale_inputs (Optional[Dict], optional): Whether to scale the input matrices. Defaults to True
+            beta_bounds (Dict[int, Tuple]): Dictionary of bounds for the different parameters.
             estimation_kwargs (Optional[Dict], optional): Dictionary of estimation method kwargs. Defaults to None.
             max_it_outer (int, optional): Maximum outer iterations for the RS algorithm. Defaults to 30.
             max_it_inner (int, optional): Maximum inner iterations for the RS algorithm. Defaults to 30.
@@ -59,9 +67,16 @@ class OnlineGamlss:
             rel_tol_inner (float, optional): Relative tolerance on the Deviance in the inner fit. Defaults to 1e-20.
             rss_tol_inner (float, optional): Tolerance for increasing RSS in the inner fit. Defaults to 1.5.
         """
-        self.distribution = distribution
-        self.forget = forget
-        self.method = method  # lasso
+        super().__init__(
+            distribution=distribution,
+            equation=equation,
+            forget=forget,
+            fit_intercept=fit_intercept,
+            method=method,
+        )
+
+        self.scaler = OnlineScaler(do_scale=scale_inputs, intercept=False)
+        self.do_scale = scale_inputs
 
         # These are global for all distribution parameters
         self.max_it_outer = max_it_outer
@@ -72,71 +87,21 @@ class OnlineGamlss:
         self.rel_tol_inner = rel_tol_inner
         self.rss_tol_inner = rss_tol_inner
 
-        handle_param_dict(
-            self=self,
-            param=do_scale,
-            default=True,
-            name="do_scale",
-            n_params=self.distribution.n_params,
-        )
-
-        handle_param_dict(
-            self=self,
-            param=expect_intercept,
-            default=True,
-            name="expect_intercept",
-            n_params=self.distribution.n_params,
-        )
-
+        # More specific args
+        if beta_bounds is not None and self.method != "lasso":
+            warnings.warn(
+                f"[{self.__class__.__name__}] "
+                f"Coefficient bounds can only be used if the estimation method == 'lasso'"
+            )
+        self.beta_bounds = {} if beta_bounds is None else beta_bounds
         for i, attribute in DEFAULT_ESTIMATOR_KWARGS.items():
             if (estimation_kwargs is not None) and (i in estimation_kwargs.keys()):
                 setattr(self, i, estimation_kwargs[i])
             else:
                 setattr(self, i, attribute)
 
-        self.scalers = {
-            i: OnlineScaler(
-                forget=self.forget,
-                intercept=self.expect_intercept[i],
-                do_scale=self.do_scale[i],
-            )
-            for i in range(self.distribution.n_params)
-        }
-
         self.is_regularized = {}
         self.rss = {}
-
-    def _scaler_train(self, X):
-        for i, x in enumerate(X):
-            self.scalers[i].fit(x)
-
-    def _scaler_update(self, X):
-        for i, x in enumerate(X):
-            self.scalers[i].partial_fit(x)
-
-    def _scaler_transform(self, X):
-        return [self.scalers[i].transform(x) for i, x in enumerate(X)]
-
-    def _make_intercept_or_x(self, x, N):
-        if x is not None:
-            # if x.shape[0] != N:
-            #     raise ValueError("X should have the same length as Y.")
-            return x
-        else:
-            return np.ones((N, 1))
-
-    def _make_input_array_list(self, x0, x1, x2, x3):
-        N = x0.shape[0]
-        X = [x0]
-
-        if 2 <= self.distribution.n_params:
-            X.append(self._make_intercept_or_x(x1, N))
-        if 3 <= self.distribution.n_params:
-            X.append(self._make_intercept_or_x(x2, N))
-        if 4 <= self.distribution.n_params:
-            X.append(self._make_intercept_or_x(x3, N))
-
-        return X
 
     def fit_beta(
         self,
@@ -151,7 +116,7 @@ class OnlineGamlss:
         param,
     ):
 
-        f = init_forget_vector(self.forget, self.n_obs)
+        f = init_forget_vector(self.forget[param], self.n_obs)
 
         if self.method == "ols":
             lambda_max = None
@@ -163,7 +128,7 @@ class OnlineGamlss:
 
             rss = np.sum(residuals**2 * w * f) / np.mean(w * f)
 
-        elif (self.method == "lasso") & self.intercept_only[param]:
+        elif (self.method == "lasso") & self._is_intercept_only(param=param):
             lambda_max = None
             lambda_path = None
             beta_path = None
@@ -215,7 +180,7 @@ class OnlineGamlss:
 
             model_params_n = np.sum(~np.isclose(beta_path, 0), axis=1)
             best_ic = select_best_model_by_information_criterion(
-                self.n_training, model_params_n, rss, self.ic[param]
+                self.n_training[param], model_params_n, rss, self.ic[param]
             )
             beta = beta_path[best_ic, :]
 
@@ -241,7 +206,7 @@ class OnlineGamlss:
     ):
 
         denom = online_mean_update(
-            self.mean_of_weights[param], w, self.forget, self.n_obs
+            self.mean_of_weights[param], w, self.forget[param], self.n_obs
         )
 
         if self.method == "ols":
@@ -255,10 +220,11 @@ class OnlineGamlss:
 
             rss = (
                 (residuals**2).flatten() * w
-                + (1 - self.forget) * (self.rss[param] * self.mean_of_weights[param])
+                + (1 - self.forget[param])
+                * (self.rss[param] * self.mean_of_weights[param])
             ) / denom
 
-        elif (self.method == "lasso") & self.intercept_only[param]:
+        elif (self.method == "lasso") & self._is_intercept_only(param=param):
             lambda_max = None
             lambda_path = None
             beta_path = None
@@ -279,7 +245,8 @@ class OnlineGamlss:
 
             rss = (
                 (residuals**2).flatten() * w
-                + (1 - self.forget) * (self.rss[param] * self.mean_of_weights[param])
+                + (1 - self.forget[param])
+                * (self.rss[param] * self.mean_of_weights[param])
             ) / denom
 
         elif self.method == "lasso":
@@ -308,12 +275,13 @@ class OnlineGamlss:
 
             rss = (
                 (residuals**2).flatten() * w
-                + (1 - self.forget) * (self.rss[param] * self.mean_of_weights[param])
+                + (1 - self.forget[param])
+                * (self.rss[param] * self.mean_of_weights[param])
             ) / denom
 
             model_params_n = np.sum(np.isclose(beta_path, 0), axis=1)
             best_ic = select_best_model_by_information_criterion(
-                self.n_training, model_params_n, rss, self.ic[param]
+                self.n_training[param], model_params_n, rss, self.ic[param]
             )
 
             self.rss_iterations_inner[param][iteration_outer][iteration_inner] = rss
@@ -323,19 +291,21 @@ class OnlineGamlss:
 
         return beta, beta_path, rss, lambda_max, lambda_path
 
-    def _make_x_gram_list(self, X, w):
-        """Make the Gramian Matrices G = X.T @ W @ GAMMA @ X"""
-        return [init_gram(x, w, self.forget) for x in X]
+    def _make_initial_fitted_values(self, y: np.ndarray) -> np.ndarray:
+        fv = np.stack(
+            [
+                self.distribution.initial_values(y, param=i)
+                for i in range(self.distribution.n_params)
+            ],
+            axis=1,
+        )
+        return fv
 
     def fit(
         self,
+        X: np.ndarray,
         y: np.ndarray,
-        x0: np.ndarray,
-        x1: Optional[np.ndarray] = None,
-        x2: Optional[np.ndarray] = None,
-        x3: Optional[np.ndarray] = None,
         sample_weights: Optional[np.ndarray] = None,
-        beta_bounds: Dict[int, Tuple] = None,
     ):
         """Fit the online GAMLSS model.
 
@@ -346,64 +316,65 @@ class OnlineGamlss:
             The provision of bounds for the coefficient vectors is only possible for LASSO/coordinate descent estimation.
 
         Args:
+            X (np.ndarray): Data Matrix. Currently supporting only numpy, will support pandas and polars in the future.
             y (np.ndarray): Response variable $Y$.
-            x0 (np.ndarray): Design matrix for the 1st distribution parameter $X_\\mu$
-            x1 (Optional[np.ndarray], optional): Design matrix for the 2nd distribution parameter $X_\\sigma$. Defaults to None.
-            x2 (Optional[np.ndarray], optional): Design matrix for the 3rd distribution parameter $X_\\nu$. Defaults to None.
-            x3 (Optional[np.ndarray], optional): Design matrix for the 4th distribution parameter $X_\\tau$. Defaults to None.
             sample_weights (Optional[np.ndarray], optional): User-defined sample weights. Defaults to None.
             beta_bounds (Dict[int, Tuple], optional): Bounds for the $\beta$ in the coordinate descent algorithm. The user needs to provide a `dict` with a mapping of tuples to distribution parameters 0, 1, 2, and 3 potentially. Defaults to None.
         """
         self.n_obs = y.shape[0]
-        self.n_training = calculate_effective_training_length(self.forget, self.n_obs)
+        self.n_training = {
+            p: calculate_effective_training_length(self.forget[p], self.n_obs)
+            for p in range(self.distribution.n_params)
+        }
 
         if sample_weights is not None:
             w = sample_weights  # Align to sklearn API
         else:
             w = np.ones(y.shape[0])
 
-        fv = np.stack(
-            [
-                self.distribution.initial_values(y, param=i)
-                for i in range(self.distribution.n_params)
-            ],
-            axis=1,
-        )
-        X = self._make_input_array_list(x0=x0, x1=x1, x2=x2, x3=x3)
-        self._scaler_train(X)
-        # self.foo = self._scaler_transform(X)
-        X_scaled = self._scaler_transform(X)
-        x_gram = self._make_x_gram_list(X=X_scaled, w=w)
-        y_gram = [np.empty((x.shape[1], 1)) for x in X]
-        beta_path = {i: np.empty((self.lambda_n, x.shape[1])) for i, x in enumerate(X)}
+        fv = self._make_initial_fitted_values(y=y)
+        self.J = self.get_J_from_equation(X=X)
+
+        # Fit scaler and transform
+        self.scaler.fit(X)
+        X_scaled = self.scaler.transform(X)
+        X_dict = {
+            p: self.make_model_array(X_scaled, param=p)
+            for p in range(self.distribution.n_params)
+        }
+        self.X_dict = X_dict
+        self.X_scaled = X_scaled
+
+        beta_path = {
+            p: np.empty((self.lambda_n, self.J[p]))
+            for p in range(self.distribution.n_params)
+        }
         rss = {i: 0 for i in range(self.distribution.n_params)}
 
-        J = {p: x.shape[1] for p, x in enumerate(X)}
-
-        self.intercept_only = {}
-        for p in range(self.distribution.n_params):
-            self.intercept_only[p] = self.expect_intercept[p] == J[p]
-
+        x_gram = {}
+        y_gram = {}
         self.weights = {}
         self.residuals = {}
 
         ## Handle parameter bounds
-        if beta_bounds is None:
+        if self.beta_bounds is None:
             self.beta_bounds = {
-                p: (np.repeat(-np.inf, J[p]), np.repeat(np.inf, J[p]))
+                p: (np.repeat(-np.inf, self.J[p]), np.repeat(np.inf, self.J[p]))
                 for p in range(self.distribution.n_params)
             }
         else:
             for p in set(range(self.distribution.n_params)).difference(
-                set(beta_bounds.keys())
+                set(self.beta_bounds.keys())
             ):
-                beta_bounds[p] = (np.repeat(-np.inf, J[p]), np.repeat(np.inf, J[p]))
-            self.beta_bounds = beta_bounds
+                self.beta_bounds[p] = (
+                    np.repeat(-np.inf, self.J[p]),
+                    np.repeat(np.inf, self.J[p]),
+                )
 
         if self.method == "lasso":
             for param in range(self.distribution.n_params):
-                is_regularized = np.repeat(True, X[param].shape[1])
-                if self.expect_intercept[p]:
+                is_regularized = np.repeat(True, self.J[param])
+                if self.fit_intercept[p]:
                     is_regularized[0] = False
                 self.is_regularized[param] = is_regularized
 
@@ -423,6 +394,7 @@ class OnlineGamlss:
         self.sum_of_weights = {}
         self.mean_of_weights = {}
 
+        # TODO: Refactor this. Almost everything can be written into class attributes during fit!
         (
             self.betas,
             self.beta_path,
@@ -435,7 +407,7 @@ class OnlineGamlss:
             self.lambda_path,
             self.lambda_max,
         ) = self._outer_fit(
-            X=X_scaled,
+            X=X_dict,
             y=y,
             w=w,
             x_gram=x_gram,
@@ -447,42 +419,10 @@ class OnlineGamlss:
             fv=fv,
         )
 
-    def update_not_inverted_gram(self, gram, x_new, w_new=1):
-        return (1 - self.forget) * gram + w_new * (x_new.T * x_new)
-
-    def update_y_gram(self, gram, x_new, y_new, w_new=1):
-        return (1 - self.forget) * gram + w_new * (x_new.T * y_new)
-
-    def update_inverted_gram(self, inv_gram, x_new, w_new=1):
-        gamma = 1 - self.forget
-        new_inv_gram = (1 / (gamma)) * (
-            inv_gram
-            - (
-                (w_new * inv_gram * x_new.T * x_new * inv_gram)
-                / (gamma + w_new * x_new * inv_gram * x_new.T)
-            )
-        )
-        return new_inv_gram
-
-    def update_gram(self, gram, x_new, w_new=1):
-        if self.method == "ols":
-            return update_inverted_gram(gram, x_new, self.forget, w_new)
-        else:
-            return self.update_not_inverted_gram(gram, x_new, w_new)
-
-    def make_x_gram(self, X, weights):
-        if self.method == "ols":
-            return init_inverted_gram(X, weights, self.forget)
-        else:
-            return init_gram(X, weights, self.forget)
-
     def update(
         self,
+        X: np.ndarray,
         y: np.ndarray,
-        x0: np.ndarray,
-        x1: Optional[np.ndarray] = None,
-        x2: Optional[np.ndarray] = None,
-        x3: Optional[np.ndarray] = None,
         sample_weights: Optional[np.ndarray] = None,
     ):
         """Update the fit for the online GAMLSS Model.
@@ -494,11 +434,8 @@ class OnlineGamlss:
             The `beta_bounds` from the initial fit are still valid for the update.
 
         Args:
+            X (np.ndarray): Data Matrix. Currently supporting only numpy, will support and pandas in the future.
             y (np.ndarray): Response variable $Y$.
-            x0 (np.ndarray): Design matrix for the 1st distribution parameter $X_\\mu$
-            x1 (Optional[np.ndarray], optional): Design matrix for the 2nd distribution parameter $X_\\sigma$. Defaults to None.
-            x2 (Optional[np.ndarray], optional): Design matrix for the 3rd distribution parameter $X_\\nu$. Defaults to None.
-            x3 (Optional[np.ndarray], optional): Design matrix for the 4th distribution parameter $X_\\tau$. Defaults to None.
             sample_weights (Optional[np.ndarray], optional): User-defined sample weights. Defaults to None.
         """
         if sample_weights is not None:
@@ -507,16 +444,21 @@ class OnlineGamlss:
             w = np.ones(y.shape[0])
 
         self.n_obs += y.shape[0]
-        self.n_training = calculate_effective_training_length(self.forget, self.n_obs)
+        self.n_training = {
+            p: calculate_effective_training_length(self.forget[p], self.n_obs)
+            for p in range(self.distribution.n_params)
+        }
 
         # More efficient to do this?!
         # Since we get better start values
-        fv = self.predict(x0=x0, x1=x1, x2=x2, x3=x3, what="response")
+        fv = self.predict(X, what="response")
 
-        X = self._make_input_array_list(x0=x0, x1=x1, x2=x2, x3=x3)
-
-        self._scaler_update(X=X)
-        X_scaled = self._scaler_transform(X=X)
+        self.scaler.partial_fit(X)
+        X_scaled = self.scaler.transform(X)
+        X_dict = {
+            p: self.make_model_array(X_scaled, param=p)
+            for p in range(self.distribution.n_params)
+        }
 
         ## Reset rss and iterations
         self.rss_iterations_inner = {i: {} for i in range(self.distribution.n_params)}
@@ -540,7 +482,7 @@ class OnlineGamlss:
             self.x_gram,
             self.y_gram,
         ) = self._outer_update(
-            X=X_scaled,
+            X=X_dict,
             y=y,
             w=w,
             x_gram=self.x_gram,
@@ -562,7 +504,7 @@ class OnlineGamlss:
     def _outer_update(self, X, y, w, x_gram, y_gram, beta_path, rss, fv):
         ## for new observations:
         global_di = -2 * np.log(self.distribution.pdf(y, fv))
-        global_dev = (1 - self.forget) * self.global_dev + global_di
+        global_dev = (1 - self.forget[0]) * self.global_dev + global_di
         global_dev_old = global_dev + 1000
         iteration_outer = 0
 
@@ -634,7 +576,7 @@ class OnlineGamlss:
         global_dev_old = global_dev + 1000
         iteration_outer = 0
 
-        betas = [np.zeros((self.lambda_n, i.shape[1])) for i in X]
+        betas = {}
 
         while True:
             # Check relative congergence
@@ -763,8 +705,9 @@ class OnlineGamlss:
             wt = np.clip(wt, 1e-10, 1e10)
             wv = eta + dl1dp1 / (dr * wt)
             ## Update the X and Y Gramian and the weight
-            x_gram[param] = self.make_x_gram(X[param], w * wt)
-            y_gram[param] = init_y_gram(X[param], wv, w * wt, self.forget)
+
+            x_gram[param] = self._make_x_gram(x=X[param], w=(w * wt), param=param)
+            y_gram[param] = self._make_y_gram(x=X[param], y=wv, w=(w * wt), param=param)
             beta_new, beta_path_new, rss_new, lambda_max_new, lambda_path_new = (
                 self.fit_beta(
                     x_gram[param],
@@ -781,7 +724,7 @@ class OnlineGamlss:
 
             if iteration_inner > 1 or iteration_outer > 1:
 
-                if self.method == "ols" or self.intercept_only[param]:
+                if self.method == "ols" or self._is_intercept_only(param=param):
                     if rss_new > (self.rss_tol_inner * rss):
                         break
                 else:
@@ -845,7 +788,7 @@ class OnlineGamlss:
         y_gram_it = self.y_gram_inner[param]
 
         di = -2 * np.log(self.distribution.pdf(y, fv))
-        dv = (1 - self.forget) * self.global_dev + np.sum(di * w)
+        dv = (1 - self.forget[0]) * self.global_dev + np.sum(di * w)
         olddv = dv + 1
 
         # Use this for the while loop
@@ -872,12 +815,11 @@ class OnlineGamlss:
             wt = np.clip(wt, -1e10, 1e10)
             wv = eta + dl1dp1 / (dr * wt)
 
-            x_gram_it = self.update_gram(x_gram[param], X[param], float(w * wt))
-            y_gram_it = self.update_y_gram(
-                y_gram[param],
-                X[param],
-                wv,
-                float(w * wt),
+            x_gram_it = self._update_x_gram(
+                gram=x_gram[param], x=X[param], w=float(w * wt), param=param
+            )
+            y_gram_it = self._update_y_gram(
+                gram=y_gram[param], x=X[param], y=wv, w=float(w * wt), param=param
             )
             beta_new, beta_path_new, rss_new, lambda_max_new, lambda_path_new = (
                 self.update_beta(
@@ -893,7 +835,7 @@ class OnlineGamlss:
                 )
             )
 
-            if self.method == "ols" or self.intercept_only[param]:
+            if self.method == "ols" or self._is_intercept_only(param=param):
                 if rss_new > (self.rss_tol_inner * rss):
                     break
             else:
@@ -913,16 +855,16 @@ class OnlineGamlss:
             fv[:, param] = self.distribution.link_inverse(eta, param=param)
 
             self.sum_of_weights_inner[param] = (
-                np.sum(w * wt) + (1 - self.forget) * self.sum_of_weights[param]
+                np.sum(w * wt) + (1 - self.forget[param]) * self.sum_of_weights[param]
             )
             self.mean_of_weights_inner[param] = (
-                self.sum_of_weights_inner[param] / self.n_training
+                self.sum_of_weights_inner[param] / self.n_training[param]
             )
 
             olddv = dv
 
             di = -2 * np.log(self.distribution.pdf(y, fv))
-            dv = np.sum(di * w) + (1 - self.forget) * self.global_dev
+            dv = np.sum(di * w) + (1 - self.forget[0]) * self.global_dev
 
         return (
             fv,
@@ -938,20 +880,14 @@ class OnlineGamlss:
 
     def predict(
         self,
-        x0: np.ndarray,
-        x1: Optional[np.ndarray] = None,
-        x2: Optional[np.ndarray] = None,
-        x3: Optional[np.ndarray] = None,
+        X: np.ndarray,
         what: str = "response",
         return_contributions: bool = False,
     ) -> np.ndarray:
         """Predict the distibution parameters given input data.
 
         Args:
-            x0 (np.ndarray): Design matrix for the 1st distribution parameter $X_\\mu$
-            x1 (Optional[np.ndarray], optional): Design matrix for the 2nd distribution parameter $X_\\sigma$. Defaults to None.
-            x2 (Optional[np.ndarray], optional): Design matrix for the 3rd distribution parameter $X_\\nu$. Defaults to None.
-            x3 (Optional[np.ndarray], optional): Design matrix for the 4th distribution parameter $X_\\tau$. Defaults to None.
+            X (np.ndarray): Design matrix.
             what (str, optional): Predict the response or the link. Defaults to "response".
             return_contributions (bool, optional): Whether to return a `Tuple[prediction, contributions]` where the contributions of the individual covariates for each distribution parameter's predicted value is specified. Defaults to False.
 
@@ -961,12 +897,17 @@ class OnlineGamlss:
         Returns:
             np.ndarray: Predicted values for the distribution.
         """
-        X = self._make_input_array_list(x0=x0, x1=x1, x2=x2, x3=x3)
-        X_scaled = self._scaler_transform(X=X)
-        prediction = [x @ b.T for x, b in zip(X_scaled, self.betas)]
+        X_scaled = self.scaler.transform(x=X)
+        X_dict = {
+            p: self.make_model_array(X_scaled, p)
+            for p in range(self.distribution.n_params)
+        }
+        prediction = [x @ b.T for x, b in zip(X_dict.values(), self.betas.values())]
 
         if return_contributions:
-            contribution = [x * b.T for x, b in zip(X_scaled, self.betas)]
+            contribution = [
+                x * b.T for x, b in zip(X_dict.values(), self.betas.values())
+            ]
 
         if what == "response":
             prediction = [

--- a/src/rolch/online_lasso.py
+++ b/src/rolch/online_lasso.py
@@ -44,13 +44,13 @@ class OnlineLasso:
             else:
                 setattr(self, i, attribute)
 
-    def fit(self, y, X, sample_weights=None, beta_bounds=None):
+    def fit(self, y, X, sample_weight=None, beta_bounds=None):
         """Fit the regression model."""
         self.N = X.shape[0]
         self.J = X.shape[1]
 
-        if sample_weights is None:
-            sample_weights = np.ones_like(y)
+        if sample_weight is None:
+            sample_weight = np.ones_like(y)
 
         if beta_bounds is None:
             self.beta_bounds = (np.repeat(-np.inf, self.J), np.repeat(np.inf, self.J))
@@ -63,8 +63,8 @@ class OnlineLasso:
         X_scaled = self.scaler.transform(X)
 
         self.beta_path = np.zeros((self.lambda_n,))
-        self.x_gram = init_gram(X_scaled, sample_weights, self.forget)
-        self.y_gram = init_y_gram(X_scaled, y, sample_weights, self.forget)
+        self.x_gram = init_gram(X_scaled, sample_weight, self.forget)
+        self.y_gram = init_y_gram(X_scaled, y, sample_weight, self.forget)
 
         self.beta_path = np.zeros((self.lambda_n, self.J))
         self.is_regularized = np.repeat(True, self.J)
@@ -102,16 +102,16 @@ class OnlineLasso:
         )
         self.beta = self.beta_path[best_ic, :]
 
-    def update(self, y, X, sample_weights=None):
+    def update(self, y, X, sample_weight=None):
         """Update the regression model"""
         self.N += X.shape[0]
         self.training_length = calculate_effective_training_length(self.forget, self.N)
         self.scaler.partial_fit(X)
         X_scaled = self.scaler.transform(X)
 
-        self.x_gram = update_gram(self.x_gram, X_scaled, self.forget, sample_weights)
+        self.x_gram = update_gram(self.x_gram, X_scaled, self.forget, sample_weight)
         self.y_gram = update_y_gram(
-            self.y_gram, X_scaled, y, self.forget, sample_weights
+            self.y_gram, X_scaled, y, self.forget, sample_weight
         )
 
         intercept = (

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -4,10 +4,10 @@
 
 def test_import():
     try:
-        import rolch
+        import rolch  # noqa
 
         failed = False
-    except Exception as e:
+    except Exception:
         failed = True
 
-    assert ~failed, f"Import failed with Exception {e}."
+    assert not failed, f"Import failed with Exception {e}."

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -10,4 +10,4 @@ def test_import():
     except Exception:
         failed = True
 
-    assert not failed, f"Import failed with Exception {e}."
+    assert not failed, f"Import failed with Exception."

--- a/tests/test_python_against_r.py
+++ b/tests/test_python_against_r.py
@@ -6,8 +6,7 @@ file = "https://gist.githubusercontent.com/seankross/a412dfbd88b3db70b74b/raw/5f
 mtcars = np.genfromtxt(file, delimiter=",", skip_header=1)[:, 1:]
 
 y = mtcars[:, 0]
-X = mtcars[:, [1, 3]]
-X = np.hstack((np.ones((y.shape[0], 1)), X))
+X = mtcars[:, 1:]
 
 
 def test_normal_distribution():
@@ -31,12 +30,13 @@ def test_normal_distribution():
 
     estimator = rolch.OnlineGamlss(
         distribution=rolch.DistributionNormal(),
+        equation={0: np.array([0, 2]), 1: np.array([0, 2])},
         method="ols",
-        do_scale=False,
-        expect_intercept=True,
+        scale_inputs=False,
+        fit_intercept=True,
         rss_tol_inner=10,
     )
-    estimator.fit(y=y, x0=X, x1=X)
+    estimator.fit(X=X y=y)
 
     assert np.allclose(
         estimator.betas[0], coef_R_mu, atol=0.01

--- a/tests/test_python_against_r.py
+++ b/tests/test_python_against_r.py
@@ -36,7 +36,7 @@ def test_normal_distribution():
         fit_intercept=True,
         rss_tol_inner=10,
     )
-    estimator.fit(X=X y=y)
+    estimator.fit(X=X, y=y)
 
     assert np.allclose(
         estimator.betas[0], coef_R_mu, atol=0.01


### PR DESCRIPTION
Starting a PR to refactor the public API for the Estimator object. 

**Goals:**

- [x]  Separate data and modeling choices by introducing the `equation` dictionary that specifies the regression equation for each distribution parameter by passing a list of column identifiers (column indices, names) or string parameters `intercept` and `all`. 
- [x]  Have only one `X` and `y` in `Estimator.fit(X, y)`
- [ ]  Basic support for `pandas` and `polars` 
- [ ]  Allow most estimation parameters to be passed either as single `int`, `bool`, `float` or as dictionary of `{parameter: value}`
- [x] Add intercept by default
- [ ] Allow to select the columns that should be scaled
- [ ] Prepare for the introduction of autoregressive effects on the distribution parameters

Discussions in #23 and #24 