### PR TITLE
Correct names for link derivatives

### DIFF
--- a/docs/links.md
+++ b/docs/links.md
@@ -8,6 +8,7 @@ For all link functions, we implement
 
 - the link \(g(x)\)
 - the inverse \(g^{-1}(x)\)
+- the derivative of the link function $\frac{\partial g(x)}{\partial x}$.
 - the first derivative _of the inverse_ of the link function \(\frac{\partial g(x)^{-1}}{\partial x}\). The choice of the inverse is justified by Equation (7) in Hirsch, Berrisch & Ziel ([2024](https://github.com/simon-hirsch/rolch/blob/main/paper.pdf)). 
 
 The link functions implemented in `ROLCH` implemenent these as class methods each. Currently, we have implemented the identity-link, log-link and  shifted log-link functions.

--- a/src/rolch/abc.py
+++ b/src/rolch/abc.py
@@ -33,8 +33,13 @@ class LinkFunction(ABC):
         """Calculate the inverse of the link function"""
 
     @abstractmethod
-    def derivative(self, x: np.ndarray) -> np.ndarray:
+    def link_derivative(self, x: np.ndarray) -> np.ndarray:
         """Calculate the first derivative of the link function"""
+        raise NotImplementedError("Currently not implemented. Will be needed for GLMs")
+
+    @abstractmethod
+    def inverse_derivative(self, x: np.ndarray) -> np.ndarray:
+        """Calculate the first derivative for the inverse link function"""
 
 
 class Distribution(ABC):

--- a/src/rolch/abc.py
+++ b/src/rolch/abc.py
@@ -71,8 +71,12 @@ class Distribution(ABC):
         """Apply the inverse of the link function for param on y."""
 
     @abstractmethod
-    def link_derivative(self, y: np.ndarray, param: int = 0) -> np.ndarray:
+    def link_function_derivative(self, y: np.ndarray, param: int = 0) -> np.ndarray:
         """Apply the derivative of the link function for param on y."""
+
+    @abstractmethod
+    def link_inverse_derivative(self, y: np.ndarray, param: int = 0) -> np.ndarray:
+        """Apply the derivative of the inverse link function for param on y."""
 
     @abstractmethod
     def initial_values(

--- a/src/rolch/distributions/gamma.py
+++ b/src/rolch/distributions/gamma.py
@@ -113,8 +113,11 @@ class DistributionGamma(Distribution):
     def link_inverse(self, y, param=0):
         return self.links[param].inverse(y)
 
-    def link_derivative(self, y, param=0):
-        return self.links[param].derivative(y)
+    def link_function_derivative(self, y: np.ndarray, param: int = 0) -> np.ndarray:
+        return self.links[param].link_derivative(y)
+
+    def link_inverse_derivative(self, y: np.ndarray, param: int = 0) -> np.ndarray:
+        return self.links[param].inverse_derivative(y)
 
     def initial_values(self, y, param=0, axis=None):
         if param == 0:

--- a/src/rolch/distributions/johnsonsu.py
+++ b/src/rolch/distributions/johnsonsu.py
@@ -184,8 +184,11 @@ class DistributionJSU(Distribution):
     def link_inverse(self, y, param=0):
         return self.links[param].inverse(y)
 
-    def link_derivative(self, y, param=0):
-        return self.links[param].derivative(y)
+    def link_function_derivative(self, y: np.ndarray, param: int = 0) -> np.ndarray:
+        return self.links[param].link_derivative(y)
+
+    def link_inverse_derivative(self, y: np.ndarray, param: int = 0) -> np.ndarray:
+        return self.links[param].inverse_derivative(y)
 
     def initial_values(self, y, param=0, axis=None):
         if param == 0:

--- a/src/rolch/distributions/normal.py
+++ b/src/rolch/distributions/normal.py
@@ -49,8 +49,11 @@ class DistributionNormal(Distribution):
     def link_inverse(self, y, param=0):
         return self.links[param].inverse(y)
 
-    def link_derivative(self, y, param=0):
-        return self.links[param].derivative(y)
+    def link_function_derivative(self, y: np.ndarray, param: int = 0) -> np.ndarray:
+        return self.links[param].link_derivative(y)
+
+    def link_inverse_derivative(self, y: np.ndarray, param: int = 0) -> np.ndarray:
+        return self.links[param].inverse_derivative(y)
 
     def initial_values(self, y, param=0, axis=None):
         if param == 0:

--- a/src/rolch/distributions/studentt.py
+++ b/src/rolch/distributions/studentt.py
@@ -95,8 +95,11 @@ class DistributionT(Distribution):
     def link_inverse(self, y, param=0):
         return self.links[param].inverse(y)
 
-    def link_derivative(self, y, param=0):
-        return self.links[param].derivative(y)
+    def link_function_derivative(self, y: np.ndarray, param: int = 0) -> np.ndarray:
+        return self.links[param].link_derivative(y)
+
+    def link_inverse_derivative(self, y: np.ndarray, param: int = 0) -> np.ndarray:
+        return self.links[param].inverse_derivative(y)
 
     def initial_values(self, y, param=0, axis=None):
         if param == 0:

--- a/src/rolch/link.py
+++ b/src/rolch/link.py
@@ -17,17 +17,20 @@ class LogLink(LinkFunction):
     def __init__(self):
         pass
 
-    def link(self, x):
+    def link(self, x: np.ndarray) -> np.ndarray:
         return np.log(np.fmax(x, LOG_LOWER_BOUND))
 
-    def inverse(self, x):
+    def inverse(self, x: np.ndarray) -> np.ndarray:
         return np.fmax(
             np.exp(np.fmin(x, EXP_UPPER_BOUND)),
             LOG_LOWER_BOUND,
         )
 
-    def derivative(self, x):
+    def inverse_derivative(self, x: np.ndarray) -> np.ndarray:
         return np.exp(np.fmin(x, EXP_UPPER_BOUND))
+
+    def link_derivative(self, x: np.ndarray) -> np.ndarray:
+        return 1 / x
 
 
 class IdentityLink(LinkFunction):
@@ -40,13 +43,16 @@ class IdentityLink(LinkFunction):
     def __init__(self):
         pass
 
-    def link(self, x):
+    def link(self, x: np.ndarray) -> np.ndarray:
         return x
 
-    def inverse(self, x):
+    def inverse(self, x: np.ndarray) -> np.ndarray:
         return x
 
-    def derivative(self, x):
+    def derivative(self, x: np.ndarray) -> np.ndarray:
+        return np.ones_like(x)
+
+    def link_derivative(self, x: np.ndarray) -> np.ndarray:
         return np.ones_like(x)
 
 
@@ -60,19 +66,22 @@ class LogShiftValueLink(LinkFunction):
     don't fall below 2, hence ensuring that the variance exists.
     """
 
-    def __init__(self, value):
+    def __init__(self, value: float):
         self.value = value
 
-    def link(self, x):
+    def link(self, x: np.ndarray) -> np.ndarray:
         return np.log(x - self.value + LOG_LOWER_BOUND)
 
-    def inverse(self, x):
+    def inverse(self, x: np.ndarray) -> np.ndarray:
         return self.value + np.fmax(
             np.exp(np.fmin(x, EXP_UPPER_BOUND)), LOG_LOWER_BOUND
         )
 
-    def derivative(self, x):
+    def inverse_derivative(self, x: np.ndarray) -> np.ndarray:
         return np.fmax(np.exp(np.fmin(x, EXP_UPPER_BOUND)), LOG_LOWER_BOUND)
+
+    def link_derivative(self, x: np.ndarray) -> np.ndarray:
+        return super().link_derivative(x)
 
 
 class LogShiftTwoLink(LogShiftValueLink):
@@ -99,14 +108,17 @@ class SqrtLink(LinkFunction):
     def __init__(self):
         pass
 
-    def link(self, x):
+    def link(self, x: np.ndarray) -> np.ndarray:
         return np.sqrt(x)
 
-    def inverse(self, x):
+    def inverse(self, x: np.ndarray) -> np.ndarray:
         return np.power(x, 2)
 
-    def derivative(self, x):
+    def inverse_derivative(self, x: np.ndarray) -> np.ndarray:
         return 2 * x
+
+    def link_derivative(self, x: np.ndarray) -> np.ndarray:
+        return 1 / (2 * np.sqrt(x))
 
 
 class SqrtShiftValueLink(LinkFunction):
@@ -119,17 +131,20 @@ class SqrtShiftValueLink(LinkFunction):
     don't fall below 2, hence ensuring that the variance exists.
     """
 
-    def __init__(self, value):
+    def __init__(self, value: float):
         self.value = value
 
-    def link(self, x):
+    def link(self, x: np.ndarray) -> np.ndarray:
         return np.sqrt(x - self.value + LOG_LOWER_BOUND)
 
-    def inverse(self, x):
+    def inverse(self, x: np.ndarray) -> np.ndarray:
         return self.value + np.power(np.fmin(x, EXP_UPPER_BOUND), 2)
 
-    def derivative(self, x):
+    def inverse_derivative(self, x: np.ndarray) -> np.ndarray:
         return 2 * x
+
+    def link_derivative(self, x: np.ndarray) -> np.ndarray:
+        return super().link_derivative(x)
 
 
 class SqrtShiftTwoLink(SqrtShiftValueLink):
@@ -158,14 +173,17 @@ class LogIdentLink(LinkFunction):
     def __init__(self):
         pass
 
-    def link(self, x: np.ndarray):
+    def link(self, x: np.ndarray) -> np.ndarray:
         return np.where(x <= 1, np.log(x), x - 1)
 
-    def inverse(self, x: np.ndarray):
+    def inverse(self, x: np.ndarray) -> np.ndarray:
         return np.where(x <= 0, np.exp(x), x + 1)
 
-    def derivative(self, x: np.ndarray):
+    def inverse_derivative(self, x: np.ndarray) -> np.ndarray:
         return np.where(x <= 0, np.exp(x), 1)
+
+    def link_derivative(self, x: np.ndarray) -> np.ndarray:
+        return super().link_derivative(x)
 
 
 __all__ = [

--- a/src/rolch/link.py
+++ b/src/rolch/link.py
@@ -49,7 +49,7 @@ class IdentityLink(LinkFunction):
     def inverse(self, x: np.ndarray) -> np.ndarray:
         return x
 
-    def derivative(self, x: np.ndarray) -> np.ndarray:
+    def inverse_derivative(self, x: np.ndarray) -> np.ndarray:
         return np.ones_like(x)
 
     def link_derivative(self, x: np.ndarray) -> np.ndarray:

--- a/src/rolch/online_gamlss.py
+++ b/src/rolch/online_gamlss.py
@@ -696,7 +696,7 @@ class OnlineGamlss(Estimator):
             iteration_inner += 1
             eta = self.distribution.link_function(fv[:, param], param=param)
             # if iteration == 1:
-            dr = 1 / self.distribution.link_derivative(eta, param=param)
+            dr = 1 / self.distribution.link_inverse_derivative(eta, param=param)
             # mu, sigma, nu vs. fv?
             dl1dp1 = self.distribution.dl1_dp1(y, fv, param=param)
             dl2dp2 = self.distribution.dl2_dp2(y, fv, param=param)
@@ -806,7 +806,7 @@ class OnlineGamlss(Estimator):
 
             iteration_inner += 1
             eta = self.distribution.link_function(fv[:, param], param=param)
-            dr = 1 / self.distribution.link_derivative(eta, param=param)
+            dr = 1 / self.distribution.link_inverse_derivative(eta, param=param)
             # mu, sigma, nu vs. fv?
             dl1dp1 = self.distribution.dl1_dp1(y, fv, param=param)
             dl2dp2 = self.distribution.dl2_dp2(y, fv, param=param)

--- a/tests/test_link_functions.py
+++ b/tests/test_link_functions.py
@@ -34,7 +34,7 @@ def test_link_positive_line(linkfun):
 
 @pytest.mark.parametrize("linkfun", SHIFTED_LINKS)
 @pytest.mark.parametrize("value", VALUES)
-def test_link_positive_line(linkfun, value):
+def test_link_positive_shifted_line(linkfun, value):
     """Test links that are shifted. This changes the domain of the links."""
     instance = linkfun(value)
     x = np.linspace(value, 100 + value, M)


### PR DESCRIPTION
In GAMLSS we commonly use the derivative of the inverse of the link function. We have implemented this as `LinkFunction.derivative()`. (1) This is confusing. (2) For GLMs we need the inverse of the link function as well. This PR corrects the naming respectively aligns it with what the function actually does. 

We then have `LinkFunction.link_derivative()` which corresponds to $\partial g(x) / \partial x$ and `LinkFunction.inverse_derivative()` which corresponds to $\partial g(x)^{-1}/\partial x$. For the `Distribution` class this applies as well.