### PR TITLE
Increase test coverage for python / numpy versions

### DIFF
--- a/.github/workflows/ci_run_tests.yml
+++ b/.github/workflows/ci_run_tests.yml
@@ -21,13 +21,14 @@ jobs:
         numpy-version: ["1.23", "1.25", "1.26", "2.0.0", "2.1.0"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.10
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: $${{matrix.python-version}}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install numpy==${{ matrix.numpy-version }}
           pip install flake8 pytest
           if [ -f requirements_tests.txt ]; then pip install -r requirements_tests.txt; fi
       - name: Build package

--- a/.github/workflows/ci_run_tests.yml
+++ b/.github/workflows/ci_run_tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12"] #  "3.13"]
         numpy-version: ["1.23", "1.25", "1.26", "2.0.0", "2.1.0"]
         exclude:
           # Old numpy version does not work properly with python > 3.11

--- a/.github/workflows/ci_run_tests.yml
+++ b/.github/workflows/ci_run_tests.yml
@@ -23,9 +23,9 @@ jobs:
         exclude:
           # Old numpy version does not work properly with python > 3.11
           - python-version: "3.12"
-            numpy-version: "1.23"
+            numpy-version: ["1.23", "1.25"]
           - python-version: "3.13"
-            numpy-version: "1.23"
+            numpy-version: ["1.23", "1.25"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -34,8 +34,8 @@ jobs:
           python-version: ${{matrix.python-version}}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install setuptools
+          python -m ensurepip --upgrade
+          python -m pip install --upgrade setuptools
           pip install numpy==${{ matrix.numpy-version }}
           pip install flake8 pytest
           if [ -f requirements_tests.txt ]; then pip install -r requirements_tests.txt; fi

--- a/.github/workflows/ci_run_tests.yml
+++ b/.github/workflows/ci_run_tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.10

--- a/.github/workflows/ci_run_tests.yml
+++ b/.github/workflows/ci_run_tests.yml
@@ -22,6 +22,10 @@ jobs:
         numpy-version: ["1.25", "1.26", "2.0.0", "2.1.0", "2.2.0"]
         exclude:
           # Old numpy version does not work properly with python > 3.11
+          - python-version: "3.12"
+            numpy-version: "1.25"
+          - python-version: "3.13"
+            numpy-version: "1.25"
           - python-version: "3.13"
             numpy-version: "1.26"
     steps:

--- a/.github/workflows/ci_run_tests.yml
+++ b/.github/workflows/ci_run_tests.yml
@@ -20,6 +20,12 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         numpy-version: ["1.23", "1.25", "1.26", "2.0.0", "2.1.0"]
+        exclude:
+          # Old numpy version does not work properly with python > 3.11
+          - python-version: "3.12"
+            numpy-version: "1.23"
+          - python-version: "3.13"
+            numpy-version: "1.23"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/ci_run_tests.yml
+++ b/.github/workflows/ci_run_tests.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m ensurepip --upgrade
+          python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
           pip install numpy==${{ matrix.numpy-version }}
           pip install flake8 pytest

--- a/.github/workflows/ci_run_tests.yml
+++ b/.github/workflows/ci_run_tests.yml
@@ -23,9 +23,13 @@ jobs:
         exclude:
           # Old numpy version does not work properly with python > 3.11
           - python-version: "3.12"
-            numpy-version: ["1.23", "1.25"]
+            numpy-version: "1.23"
+          - python-version: "3.12"
+            numpy-version: "1.25"
           - python-version: "3.13"
-            numpy-version: ["1.23", "1.25", "1.26"]
+            numpy-version: "1.23"
+          - python-version: "3.13"
+            numpy-version: "1.25"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/ci_run_tests.yml
+++ b/.github/workflows/ci_run_tests.yml
@@ -15,6 +15,7 @@ jobs:
     # runs-on: ubuntu-latest
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]

--- a/.github/workflows/ci_run_tests.yml
+++ b/.github/workflows/ci_run_tests.yml
@@ -30,6 +30,8 @@ jobs:
             numpy-version: "1.23"
           - python-version: "3.13"
             numpy-version: "1.25"
+          - python-version: "3.13"
+            numpy-version: "1.26"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/ci_run_tests.yml
+++ b/.github/workflows/ci_run_tests.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install setuptools
           pip install numpy==${{ matrix.numpy-version }}
           pip install flake8 pytest
           if [ -f requirements_tests.txt ]; then pip install -r requirements_tests.txt; fi

--- a/.github/workflows/ci_run_tests.yml
+++ b/.github/workflows/ci_run_tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: $${{matrix.python-version}}
+          python-version: ${{matrix.python-version}}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci_run_tests.yml
+++ b/.github/workflows/ci_run_tests.yml
@@ -19,17 +19,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12"] #  "3.13"]
-        numpy-version: ["1.23", "1.25", "1.26", "2.0.0", "2.1.0"]
+        numpy-version: ["1.25", "1.26", "2.0.0", "2.1.0", "2.2.0"]
         exclude:
           # Old numpy version does not work properly with python > 3.11
-          - python-version: "3.12"
-            numpy-version: "1.23"
-          - python-version: "3.12"
-            numpy-version: "1.25"
-          - python-version: "3.13"
-            numpy-version: "1.23"
-          - python-version: "3.13"
-            numpy-version: "1.25"
           - python-version: "3.13"
             numpy-version: "1.26"
     steps:

--- a/.github/workflows/ci_run_tests.yml
+++ b/.github/workflows/ci_run_tests.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        numpy-version: ["1.23", "1.25", "1.26", "2.0.0", "2.1.0"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.10

--- a/.github/workflows/ci_run_tests.yml
+++ b/.github/workflows/ci_run_tests.yml
@@ -25,7 +25,7 @@ jobs:
           - python-version: "3.12"
             numpy-version: ["1.23", "1.25"]
           - python-version: "3.13"
-            numpy-version: ["1.23", "1.25"]
+            numpy-version: ["1.23", "1.25", "1.26"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/ci_run_tests_deps.yml
+++ b/.github/workflows/ci_run_tests_deps.yml
@@ -18,10 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12"] # "3.13"]
         numpy-version: ["1.26", "2.0.0", "2.1.0", "2.2.0"]
         exclude:
-          # Old numpy version does not work properly with python > 3.11
           - python-version: "3.13"
             numpy-version: "1.26"
     steps:

--- a/.github/workflows/ci_run_tests_deps.yml
+++ b/.github/workflows/ci_run_tests_deps.yml
@@ -1,0 +1,47 @@
+name: Automated Tests
+on:
+  push:
+    branches:    
+      - '**'            # matches every branch
+      - '!gh-pages'     # excludes gh-pages
+  pull_request:
+    branches:    
+    - '**'              # matches every branch
+    - '!gh-pages'       # excludes gh-pages
+permissions:
+  contents: read
+jobs:
+  build:
+    # runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        numpy-version: ["1.26", "2.0.0", "2.1.0", "2.2.0"]
+        exclude:
+          # Old numpy version does not work properly with python > 3.11
+          - python-version: "3.13"
+            numpy-version: "1.26"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{matrix.python-version}}
+      - name: Install dependencies
+        run: |
+          python -m ensurepip --upgrade
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
+          pip install numpy==${{ matrix.numpy-version }}
+          pip install flake8 pytest
+          if [ -f requirements_tests.txt ]; then pip install -r requirements_tests.txt; fi
+      - name: Build package
+        run: python -m build --wheel
+      - name: Install Package
+        run: pip install dist/*
+      - name: Run tests with pytest
+        run: pytest tests
+

--- a/.github/workflows/ci_run_tests_os.yml
+++ b/.github/workflows/ci_run_tests_os.yml
@@ -30,7 +30,7 @@ jobs:
           python -m ensurepip --upgrade
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
-          pip install numpy==${{ matrix.numpy-version }}
+          pip install numpy
           pip install flake8 pytest
           if [ -f requirements_tests.txt ]; then pip install -r requirements_tests.txt; fi
       - name: Build package

--- a/.github/workflows/ci_run_tests_os.yml
+++ b/.github/workflows/ci_run_tests_os.yml
@@ -18,16 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12"] #  "3.13"]
-        numpy-version: ["1.25", "1.26", "2.0.0", "2.1.0", "2.2.0"]
-        exclude:
-          # Old numpy version does not work properly with python > 3.11
-          - python-version: "3.12"
-            numpy-version: "1.25"
-          - python-version: "3.13"
-            numpy-version: "1.25"
-          - python-version: "3.13"
-            numpy-version: "1.26"
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 description = "Methods for online / incremental estimation of distributional regression models"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10, <3.13" # Introduce hard cap on python due to numba
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies=[
-    "scipy >= 1.00, <2.0.0",
+    "scipy >= 1.00, <2.2.0",
     "numpy >= 1.2, <2.0.0",
     "numba >= 0.59.1, < 1.0.0"
 ]

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,5 +1,4 @@
-numpy>1.26.0, <2.0.0
-numba>0.59, <1.0.0
+numba>0.59
 scipy
 scikit-learn
 build

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,4 +1,4 @@
-numba>0.59
+numba
 scipy
 scikit-learn
 build


### PR DESCRIPTION
- Add python 3.13 to tests
- Add matrix strategy to test against multiply numpy versions
- `numba` currently does not support python 3.13, but will be in the upcoming release, see https://github.com/numba/numba/issues/9798