### PR TITLE
Add batch updates for Gramians

### DIFF
--- a/example.ipynb
+++ b/example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 1,
    "id": "e37ae52f-fa91-4128-9580-d12c61984cc7",
    "metadata": {},
    "outputs": [
@@ -10,7 +10,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.1.8\n"
+      "0.1.9\n"
      ]
     }
    ],
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 2,
    "id": "1fd422ca-82aa-44d2-8287-5bfcae8c6d4e",
    "metadata": {},
    "outputs": [],
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 3,
    "id": "558ca51e-a311-4d4b-87b5-17986b364ed3",
    "metadata": {},
    "outputs": [
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 4,
    "id": "2d8d950d-3749-4c86-8f05-8082b9e25ae4",
    "metadata": {},
    "outputs": [
@@ -163,7 +163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 5,
    "id": "7e8a74f8-f170-440e-a27f-fa3a14c0b924",
    "metadata": {},
    "outputs": [
@@ -203,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 6,
    "id": "3a3740ca-2c78-427a-b1d1-b4e2a5abcdd7",
    "metadata": {},
    "outputs": [
@@ -238,7 +238,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "rolch310",
    "language": "python",
    "name": "python3"
   },

--- a/tests/test_gram.py
+++ b/tests/test_gram.py
@@ -1,0 +1,125 @@
+import numpy as np
+import pytest
+import scipy.stats as st
+
+from rolch.gram import (
+    init_gram,
+    init_inverted_gram,
+    init_y_gram,
+    update_gram,
+    update_inverted_gram,
+    update_y_gram,
+)
+
+
+def make_x_y_w(N, D, random_weights=True):
+    X = st.multivariate_normal().rvs((N, D))
+    if D == 1:
+        X = X.reshape(-1, 1)
+    y = st.multivariate_normal().rvs((N, 1))
+    if random_weights:
+        w = st.uniform().rvs(N)
+    else:
+        w = np.ones(N)
+    return X, y, w
+
+
+N = [100, 1000]
+D = [1, 2, 10]
+RANDOM_WEIGHTS = [True, False]
+FORGET = [0, 0.0001, 0.001, 0.01, 0.1]
+BATCH_SIZE = [10, 25]
+
+
+@pytest.mark.parametrize("N", N)
+@pytest.mark.parametrize("D", D)
+@pytest.mark.parametrize("random_weights", RANDOM_WEIGHTS)
+@pytest.mark.parametrize("forget", FORGET)
+def test_single_update_x_gram(N, D, random_weights, forget):
+    X, _, w = make_x_y_w(N, D, random_weights=random_weights)
+    gram_start = init_gram(X[:-1], w[:-1], forget)
+    gram_final = init_gram(X, w, forget)
+    assert np.allclose(
+        gram_final, update_gram(gram_start, X[[-1]], forget=forget, w=w[-1])
+    )
+
+
+@pytest.mark.parametrize("N", N)
+@pytest.mark.parametrize("D", D)
+@pytest.mark.parametrize("random_weights", RANDOM_WEIGHTS)
+@pytest.mark.parametrize("forget", FORGET)
+@pytest.mark.parametrize("batchsize", BATCH_SIZE)
+def test_batch_update_x_gram(N, D, random_weights, forget, batchsize):
+    X, _, w = make_x_y_w(N, D, random_weights=random_weights)
+    gram_start = init_gram(X[:-batchsize], w[:-batchsize], forget)
+    gram_final = init_gram(X, w, forget)
+    assert np.allclose(
+        gram_final,
+        update_gram(gram_start, X[-batchsize:, :], forget=forget, w=w[-batchsize:]),
+    )
+
+
+# INVERTED GRAM
+@pytest.mark.parametrize("N", N)
+@pytest.mark.parametrize("D", D)
+@pytest.mark.parametrize("random_weights", RANDOM_WEIGHTS)
+@pytest.mark.parametrize("forget", FORGET)
+def test_single_update_inv_gram(N, D, random_weights, forget):
+    X, _, w = make_x_y_w(N, D, random_weights=random_weights)
+    gram_start = init_inverted_gram(X[:-1], w[:-1], forget)
+    gram_final = init_inverted_gram(X, w, forget)
+    assert np.allclose(
+        gram_final, update_inverted_gram(gram_start, X[[-1]], forget=forget, w=w[-1])
+    )
+
+
+@pytest.mark.parametrize("N", N)
+@pytest.mark.parametrize("D", D)
+@pytest.mark.parametrize("random_weights", RANDOM_WEIGHTS)
+@pytest.mark.parametrize("forget", FORGET)
+@pytest.mark.parametrize("batchsize", BATCH_SIZE)
+def test_batch_update_inv_gram(N, D, random_weights, forget, batchsize):
+    X, _, w = make_x_y_w(N, D, random_weights=random_weights)
+    gram_start = init_inverted_gram(X[:-batchsize], w[:-batchsize], forget)
+    gram_final = init_inverted_gram(X, w, forget)
+    assert np.allclose(
+        gram_final,
+        update_inverted_gram(
+            gram_start, X[-batchsize:, :], forget=forget, w=w[-batchsize:]
+        ),
+    )
+
+
+# Y-GRAM
+@pytest.mark.parametrize("N", N)
+@pytest.mark.parametrize("D", D)
+@pytest.mark.parametrize("random_weights", RANDOM_WEIGHTS)
+@pytest.mark.parametrize("forget", FORGET)
+def test_single_update_y_gram(N, D, random_weights, forget):
+    X, y, w = make_x_y_w(N, D, random_weights=random_weights)
+    gram_start = init_y_gram(X[:-1], y[:-1], w[:-1], forget)
+    gram_final = init_y_gram(X, y, w, forget)
+    assert np.allclose(
+        gram_final, update_y_gram(gram_start, X[[-1]], y[[-1]], forget=forget, w=w[-1])
+    )
+
+
+@pytest.mark.parametrize("N", N)
+@pytest.mark.parametrize("D", D)
+@pytest.mark.parametrize("random_weights", RANDOM_WEIGHTS)
+@pytest.mark.parametrize("forget", FORGET)
+@pytest.mark.parametrize("batchsize", BATCH_SIZE)
+def test_batch_update_y_gram(N, D, random_weights, forget, batchsize):
+    X, y, w = make_x_y_w(N, D, random_weights=random_weights)
+    gram_start = init_y_gram(X[:-batchsize], y[:-batchsize], w[:-batchsize], forget)
+    gram_final = init_y_gram(X, y, w, forget)
+    assert np.allclose(
+        gram_final,
+        update_y_gram(
+            gram_start,
+            X[-batchsize:, :],
+            y[-batchsize:],
+            forget=forget,
+            w=w[-batchsize:],
+        ),
+    )


### PR DESCRIPTION
This PR adds the possibility to batch-update the gramian matrices to the package. This is the first step towards proper (mini-) batch updates in our package. 

This PR additionally adds a whole lot of testing around the Gramian matrices, including verifying that
- plain single step updates work as expected
- batch updates work as expected

for 
- multiple dimensions
- multiple forgets
- constant and random weights