### PR TITLE
Fix estimator.get_j_from_equation

### DIFF
--- a/src/rolch/estimators/online_gamlss.py
+++ b/src/rolch/estimators/online_gamlss.py
@@ -234,9 +234,21 @@ class OnlineGamlss(Estimator):
                     J[p] = X.shape[1] + int(self.fit_intercept[p])
                 if self.equation[p] == "intercept":
                     J[p] = 1
-            elif isinstance(self.equation[p], np.ndarray) or isinstance(
-                self.equation[p], list
-            ):
+            elif isinstance(self.equation[p], np.ndarray):
+                if np.issubdtype(self.equation[p].dtype, bool):
+                    if self.equation[p].shape[0] != X.shape[1]:
+                        raise ValueError(f"Shape does not match for param {p}.")
+                    J[p] = np.sum(self.equation[p]) + int(self.fit_intercept[p])
+                elif np.issubdtype(self.equation[p].dtype, np.integer):
+                    if self.equation[p].max() >= X.shape[1]:
+                        raise ValueError(f"Shape does not match for param {p}.")
+                    J[p] = self.equation[p].shape[0] + int(self.fit_intercept[p])
+                else:
+                    raise ValueError(
+                        "If you pass a np.ndarray in the equation, "
+                        "please make sure it is of dtype bool or int."
+                    )
+            elif isinstance(self.equation[p], list):
                 J[p] = len(self.equation[p]) + int(self.fit_intercept[p])
             else:
                 raise ValueError("Something unexpected happened")

--- a/tests/test_online_gamlss.py
+++ b/tests/test_online_gamlss.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pytest
+from sklearn.datasets import make_regression
+
+from rolch.distributions import DistributionJSU
+from rolch.estimators import OnlineGamlss
+
+FIT_INTERCEPT = [True, False]
+N_FEATURES = np.round(np.geomspace(1, 100, 20)).astype(int)
+
+
+@pytest.mark.parametrize("n_features", N_FEATURES)
+@pytest.mark.parametrize("fit_intercept", FIT_INTERCEPT)
+def test_get_J_from_equation(n_features, fit_intercept):
+
+    # For param 3:
+    # We need at least the 10 first ones to check whether we fail on wrong dims
+    # For everything else, we want to have the correct dims for the boolean array.
+
+    if n_features <= 10:
+        bool_array = np.repeat(True, 10)
+    else:
+        bool_array = np.concatenate(
+            (np.repeat(True, 10), np.repeat(False, n_features - 10))
+        )
+
+    equation = {
+        0: "all",  # should adjust to n_features
+        1: "intercept",
+        2: np.arange(0, 4),
+        3: bool_array,
+    }
+
+    EXPECTED = {
+        0: {True: n_features + 1, False: n_features},
+        1: {True: 1, False: 1},
+        2: {True: 5, False: 4},
+        3: {True: 11, False: 10},
+    }
+
+    X, _ = make_regression(n_samples=100, n_features=n_features)
+    distribution = DistributionJSU()
+
+    estimator = OnlineGamlss(
+        distribution=distribution,
+        equation=equation,
+        fit_intercept=fit_intercept,
+    )
+
+    if n_features < 4:
+        with pytest.raises(ValueError):
+            # We want to complain about parameter 2 because the max value in the int is
+            print(n_features)
+            J = estimator.get_J_from_equation(X)
+    if (n_features >= 4) and (n_features <= 10):
+        # Then we will fail on the boolean.
+        # We check the integer array before, so this will still fail before
+        with pytest.raises(ValueError):
+            J = estimator.get_J_from_equation(X)
+    if n_features > 10:
+        J = estimator.get_J_from_equation(X)
+        assert J[0] == EXPECTED[0][fit_intercept], "Wrong J for param == 0"
+        assert J[1] == EXPECTED[1][fit_intercept], "Wrong J for param == 1"
+        assert J[2] == EXPECTED[2][fit_intercept], "Wrong J for param == 2"
+        assert J[3] == EXPECTED[3][fit_intercept], "Wrong J for param == 3"

--- a/tests/test_online_gamlss.py
+++ b/tests/test_online_gamlss.py
@@ -6,29 +6,18 @@ from rolch.distributions import DistributionJSU
 from rolch.estimators import OnlineGamlss
 
 FIT_INTERCEPT = [True, False]
-N_FEATURES = np.round(np.geomspace(1, 100, 20)).astype(int)
+N_FEATURES = np.round(np.geomspace(11, 100, 5)).astype(int)
 
 
 @pytest.mark.parametrize("n_features", N_FEATURES)
 @pytest.mark.parametrize("fit_intercept", FIT_INTERCEPT)
 def test_get_J_from_equation(n_features, fit_intercept):
 
-    # For param 3:
-    # We need at least the 10 first ones to check whether we fail on wrong dims
-    # For everything else, we want to have the correct dims for the boolean array.
-
-    if n_features <= 10:
-        bool_array = np.repeat(True, 10)
-    else:
-        bool_array = np.concatenate(
-            (np.repeat(True, 10), np.repeat(False, n_features - 10))
-        )
-
     equation = {
         0: "all",  # should adjust to n_features
         1: "intercept",
         2: np.arange(0, 4),
-        3: bool_array,
+        3: np.array([True] * 10 + [False] * (n_features - 10)).astype(bool),
     }
 
     EXPECTED = {
@@ -47,19 +36,54 @@ def test_get_J_from_equation(n_features, fit_intercept):
         fit_intercept=fit_intercept,
     )
 
-    if n_features < 4:
-        with pytest.raises(ValueError):
-            # We want to complain about parameter 2 because the max value in the int is
-            print(n_features)
-            J = estimator.get_J_from_equation(X)
-    if (n_features >= 4) and (n_features <= 10):
-        # Then we will fail on the boolean.
-        # We check the integer array before, so this will still fail before
-        with pytest.raises(ValueError):
-            J = estimator.get_J_from_equation(X)
-    if n_features > 10:
+    J = estimator.get_J_from_equation(X)
+    assert J[0] == EXPECTED[0][fit_intercept], "Wrong J for param == 0"
+    assert J[1] == EXPECTED[1][fit_intercept], "Wrong J for param == 1"
+    assert J[2] == EXPECTED[2][fit_intercept], "Wrong J for param == 2"
+    assert J[3] == EXPECTED[3][fit_intercept], "Wrong J for param == 3"
+
+
+def test_get_J_from_equation_warnings():
+
+    n_features = 10
+    fit_intercept = True
+
+    equation_fail_2 = {
+        0: "all",  # should adjust to n_features
+        1: "intercept",
+        2: np.arange(0, 20),
+        3: np.array([True] * n_features).astype(bool),
+    }
+
+    X, _ = make_regression(n_samples=100, n_features=n_features)
+    distribution = DistributionJSU()
+
+    estimator = OnlineGamlss(
+        distribution=distribution,
+        equation=equation_fail_2,
+        fit_intercept=fit_intercept,
+    )
+    with pytest.raises(ValueError, match="Shape does not match for param 2."):
         J = estimator.get_J_from_equation(X)
-        assert J[0] == EXPECTED[0][fit_intercept], "Wrong J for param == 0"
-        assert J[1] == EXPECTED[1][fit_intercept], "Wrong J for param == 1"
-        assert J[2] == EXPECTED[2][fit_intercept], "Wrong J for param == 2"
-        assert J[3] == EXPECTED[3][fit_intercept], "Wrong J for param == 3"
+
+    # Test for parameter three
+    equation_fail_3 = {
+        0: "all",  # should adjust to n_features
+        1: "intercept",
+        2: np.arange(0, n_features),
+        3: np.array([True, False] * 10).astype(bool),
+    }
+
+    X, _ = make_regression(n_samples=100, n_features=10)
+    distribution = DistributionJSU()
+    estimator = OnlineGamlss(
+        distribution=distribution,
+        equation=equation_fail_3,
+        fit_intercept=fit_intercept,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Shape does not match for param 3.",
+    ):
+        J = estimator.get_J_from_equation(X)


### PR DESCRIPTION
I noted that we fail the user if someone passes an array of booleans to index the X as equation. 

This happens because we don't properly check the dtype of the contents of the equation.