### PR TITLE
Ignore some nix-specific files and folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.ruff_cache*
 *__pycache__*
 .ipynb_checkpoints
-.git/* 
+.git/*
 dist
 dist_old
 development
@@ -18,3 +18,7 @@ presentation/*
 .coverage
 build.txt
 gist.githubusercontent*
+.direnv/*
+.venv/*
+.envrc
+default.nix


### PR DESCRIPTION
This PR extend the .gitignore by some files and folders that are created on NixOS when using `nix-shell` together with `default.nix`.