### PR TITLE
Restrict CI tests to PR's and pushes to main.

### DIFF
--- a/.github/workflows/ci_run_tests_deps.yml
+++ b/.github/workflows/ci_run_tests_deps.yml
@@ -2,7 +2,7 @@ name: Automated Tests for dependencies
 on:
   push:
     branches:    
-      - '**'            # matches every branch
+      - main            # only run on pushes to main
       - '!gh-pages'     # excludes gh-pages
   pull_request:
     branches:    

--- a/.github/workflows/ci_run_tests_os.yml
+++ b/.github/workflows/ci_run_tests_os.yml
@@ -2,7 +2,7 @@ name: Automated Tests for OS
 on:
   push:
     branches:    
-      - '**'            # matches every branch
+      - main            # only run on pushes to main
       - '!gh-pages'     # excludes gh-pages
   pull_request:
     branches:    


### PR DESCRIPTION
Merging into main will also trigger the tests as it creates a push event on main.