### PR TITLE
FIX: Allow multi step online mean updates in the utils function

### DIFF
--- a/src/rolch/utils.py
+++ b/src/rolch/utils.py
@@ -72,19 +72,42 @@ def calculate_effective_training_length(forget: float, n_obs: int):
         return (1 - (1 - forget) ** n_obs) / forget
 
 
-def online_mean_update(avg: float, value: float, forget: float, n_seen: int):
-
+def _online_mean_update(avg: float, value: float, forget: float, n_seen: int):
     n_asymmptotic = calculate_asymptotic_training_length(forget)
     n_eff = calculate_effective_training_length(forget, n_seen)
-
     forget_scaled = forget * np.maximum(n_asymmptotic / n_eff, 1.0)
-
     diff = value - avg
     incr = forget_scaled * diff
-
     if forget_scaled > 0:
         new_avg = avg + incr
     else:
         new_avg = avg + diff / n_seen
-
     return new_avg
+
+
+def online_mean_update(
+    avg: float,
+    value: float | np.ndarray,
+    forget: float,
+    n_seen: int,
+) -> float:
+    """Update the average with a new value using an online mean update.
+
+    Args:
+        avg (float): The current average.
+        value (float): The new value to update the average with.
+        forget (float): The forgetting factor.
+        n_seen (int): The number of observations seen so far.
+
+    Returns:
+        float: The updated average.
+    """
+    if isinstance(value, np.ndarray):
+        _avg = float(avg)
+        for i, v in zip(range(-value.shape[0] + 1, 1), value, strict=True):
+            # Substract since we expect n_seen to be number of observations INCLUDING
+            # the ones in values
+            _avg = _online_mean_update(_avg, v, forget, n_seen + i)
+        return _avg
+    else:
+        return _online_mean_update(avg, value, forget, n_seen)

--- a/src/rolch/utils.py
+++ b/src/rolch/utils.py
@@ -91,11 +91,12 @@ def online_mean_update(
     forget: float,
     n_seen: int,
 ) -> float:
-    """Update the average with a new value using an online mean update.
+    """Update the average with a new value or an array of values using an online mean update.
 
     Args:
         avg (float): The current average.
-        value (float): The new value to update the average with.
+        value (float | np.ndarray): The new value or array of values to update the average with.
+            If `value` is an array, the average is updated iteratively for each element.
         forget (float): The forgetting factor.
         n_seen (int): The number of observations seen so far.
 


### PR DESCRIPTION
This fix allows multi-step updates in the online_mean_update function and thereby stops the online model selection function from breaking for mini-batch updates.