### PR TITLE
Test ruff

### DIFF
--- a/.github/workflows/ci_run_tests_deps.yml
+++ b/.github/workflows/ci_run_tests_deps.yml
@@ -1,9 +1,6 @@
 name: Automated Tests for dependencies
 on:
-  workflow_run:
-    workflows: ["Lint and Commit"]
-    types:
-      - completed
+  workflow_call:
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/ci_run_tests_os.yml
+++ b/.github/workflows/ci_run_tests_os.yml
@@ -1,9 +1,6 @@
 name: Automated Tests for OS
 on:
-  workflow_run:
-    workflows: ["Lint and Commit"]
-    types:
-      - completed 
+  workflow_call:
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -45,3 +45,15 @@ jobs:
 
     - name: Lint (fail if formatting is wrong)
       run: ruff check .
+
+  run-tests-deps:
+    needs: lint
+    uses: ./.github/workflows/ci_run_tests_deps.yml
+    permissions:
+      contents: read
+
+  run-tests-os:
+    needs: lint
+    uses: ./.github/workflows/ci_run_tests_os.yml
+    permissions:
+      contents: read


### PR DESCRIPTION
This convert the workflow logic from using workflow_run triggers to workflow_call triggers. These are better as they maintain the context (PR / Commit etc.)