### PR TITLE
Refactor problematic columns handling

### DIFF
--- a/src/ondil/terms/linear_terms.py
+++ b/src/ondil/terms/linear_terms.py
@@ -102,7 +102,8 @@ class _LinearBaseTerm(Term):
             distribution=distribution,
         )
         self.find_zero_variance_columns(X_mat)
-        X_mat = self.remove_zero_variance_columns(X_mat)
+        self.find_multicollinear_columns(X_mat)
+        X_mat = self.remove_problematic_columns(X_mat)
 
         if self.is_regularized:
             is_regularized = self.is_regularized
@@ -343,7 +344,8 @@ class _LinearPathModelSelectionIC(Term):
         )
 
         self.find_zero_variance_columns(X_mat)
-        X_mat = self.remove_zero_variance_columns(X_mat)
+        self.find_multicollinear_columns(X_mat)
+        X_mat = self.remove_problematic_columns(X_mat)
 
         if self.is_regularized:
             is_regularized = self.is_regularized


### PR DESCRIPTION
**Refactoring and modularization of column removal:**

* Added `remove_multicollinear_columns` and `remove_problematic_columns` methods to `src/ondil/base/terms.py`, allowing separate or combined removal of zero-variance and multicollinear columns from the design matrix.
* Updated `remove_zero_variance_columns` to only remove zero-variance columns, and made its behavior more robust by checking for attribute existence.

**Improvements to detection methods:**

* Changed `find_zero_variance_columns` to return the indices of zero-variance columns directly, and removed side effects and print statements.
* Updated `find_multicollinear_columns` to return the indices of multicollinear columns as a sorted NumPy array.

**Integration in fitting routines:**

* Updated `_fit` methods in `src/ondil/terms/linear_terms.py` to use the new `remove_problematic_columns` method, ensuring both zero-variance and multicollinear columns are removed in a single step after detection. [[1]](diffhunk://#diff-eec397fd48b952c277fab4e5864dddec090c98f677f4211cc2c5db4bb4d46650L105-R106) [[2]](diffhunk://#diff-eec397fd48b952c277fab4e5864dddec090c98f677f4211cc2c5db4bb4d46650L346-R348)