### PR TITLE
Smooth terms

### DIFF
--- a/PSPLINE_PLAN.md
+++ b/PSPLINE_PLAN.md
@@ -1,0 +1,146 @@
+# Implementation Plan: Online P-Spline Terms
+
+Add univariate penalized B-spline (P-spline) terms to the terms-based
+`OnlineStructuredAdditiveDistributionRegressor`, by (1) building a B-spline basis +
+difference-penalty module, (2) extending the numba coordinate descent to support general
+quadratic penalty matrices alongside L1, and (3) adding a `PSplineTerm` that selects λ over a
+grid via EDF-based information criteria — reusing the existing Gram-matrix, forgetting,
+path/warm-start, and immutable-term-state machinery.
+
+The codebase is well-prepared: terms already follow a backfitting protocol on working-vector
+residuals, so each P-spline term solves its own small K×K penalized WLS subproblem.
+
+> Status: delegated to the GitHub Copilot coding agent —
+> [PR #197](https://github.com/simon-hirsch/ondil/pull/197) (base: `smooth-terms`).
+
+## Background
+
+The online weighted least-squares subproblem in ondil's IRLS loop is
+
+$$
+\min_\beta \tfrac12 (z - X\beta)^\top W (z - X\beta) + \text{regularization}.
+$$
+
+For a P-spline term, the regularization is a quadratic penalty
+$\tfrac12 \lambda \, \beta^\top S \beta$ with $S = D_q^\top D_q$, where $D_q$ is the $q$-th
+order difference operator on adjacent spline coefficients. In Gram form the inner objective
+becomes
+
+$$
+\min_\beta \tfrac12 \beta^\top (G + \lambda S)\beta - h^\top \beta,
+\qquad G = X^\top W X, \quad h = X^\top W z .
+$$
+
+So P-splines are not a new model class for ondil — they are a banded quadratic penalty added
+to the existing online Gramian machinery.
+
+## Steps
+
+### Phase 1 — Basis & penalty (new file `src/ondil/terms/splines.py`)
+
+1. B-spline basis with equidistant knots fixed from the data range at `fit` time
+   (degree `p`, default cubic), evaluated via `scipy.interpolate.BSpline.design_matrix`;
+   linear extrapolation beyond boundary knots for prediction (mgcv `bs="ps"` behavior).
+2. Difference penalty: $D_q = \Delta^q I_K$, $S = D_q^\top D_q$ (default $q = 2$),
+   normalized (e.g. by Frobenius norm) so λ has comparable meaning across terms.
+3. Identifiability: center basis columns using weighted column means stored at fit time
+   (sum-to-zero style); the term carries no intercept, avoiding clashes with
+   `InterceptTerm` in the backfitting loop.
+
+### Phase 2 — Solver extension (parallel with Phase 1)
+
+4. New numba functions in `src/ondil/coordinate_descent/cd_base.py` (or a sibling module):
+   a quadratic-penalty CD that uses $G + \lambda S$ in the coordinate numerator/denominator
+   while keeping soft-thresholding for any L1 part, and a path variant looping a λ-grid with
+   warm starts via the existing `get_start_beta`. With $S = 0$ it must reduce exactly to the
+   current `online_coordinate_descent`.
+5. New `QuadraticPenaltyPath(EstimationMethod)` in `src/ondil/methods/quadratic_penalty.py`:
+   `_path_based_method=True`, takes the term's penalty matrix, a geometric λ-grid
+   (`lambda_n`, `lambda_eps`) or fixed `lambda_`, reuses `init_gram`/`update_gram` with
+   forgetting; register a string alias in `get_estimation_method`.
+
+### Phase 3 — `PSplineTerm` (depends on 1–5)
+
+6. Frozen `PSplineTermState` (knots, column means, `g`, `h`, `coef_path_`, `lambda_grid`,
+   `edf_`, `ic_values_`, `best_idx`, `coef_`) following the `RegularizedLinearTermState`
+   pattern in `src/ondil/terms/linear.py`.
+7. `PSplineTerm(Term)` with `feature`, `n_splines=20`, `degree=3`, `diff_order=2`,
+   `lambda_=None` (None → grid selection), `ic="aic"`, `forget` — implementing the full
+   `Term` protocol (`fit` / `update` returning new instances, `predict_in_sample_during_*`,
+   `predict_out_of_sample`, `make_design_matrix_*`, `_prepare_term`). Model selection mirrors
+   `_LinearPathModelSelection._fit` but with
+   $\mathrm{edf}(\lambda) = \mathrm{tr}\big((G + \lambda S)^{-1} G\big)$ as `n_parameters`
+   instead of nonzero counts.
+8. Export from `src/ondil/terms/__init__.py` and the package root; no estimator changes
+   needed since `PSplineTerm` conforms to the existing term protocol consumed by
+   `src/ondil/estimators/online_struct_add_distreg.py`.
+
+### Phase 4 — Plumbing & docs
+
+9. Verify `InformationCriterion` (`src/ondil/information_criteria.py`) handles fractional
+   (float) `n_parameters`; adjust if int-assumed. Use `calculate_effective_training_length`
+   for `n_observations` under forgetting.
+10. Brief docs entry (terms page) + an example script under `examples/`.
+
+## Relevant Files
+
+- `src/ondil/terms/splines.py` — new: basis, penalty, `PSplineTerm`, `PSplineTermState`
+- `src/ondil/coordinate_descent/cd_base.py` — quadratic-penalty CD + path variant
+  (reuse `soft_threshold`, `get_start_beta`, active-set + tolerance logic)
+- `src/ondil/methods/quadratic_penalty.py` — new `QuadraticPenaltyPath` method;
+  register in `src/ondil/methods/__init__.py`
+- `src/ondil/terms/linear.py` — reference: `_LinearPathModelSelection` fit/IC-selection
+  pattern and immutable state handling
+- `src/ondil/gram.py` — reuse `init_gram` / `update_gram` /
+  `calculate_effective_training_length`
+- `src/ondil/information_criteria.py` — float-edf compatibility
+- `tests/test_terms_pspline.py` — new test module
+
+## Verification
+
+1. Basis unit tests: partition of unity inside the domain, correct shape, exact linearity of
+   extrapolation beyond boundary knots.
+2. Penalty tests: $S$ annihilates polynomials up to degree $q-1$; bandedness.
+3. Solver equivalence: quadratic-CD with no L1 matches `np.linalg.solve(G + λS, h)` to
+   tolerance; with $S = 0$ matches the existing CD path bit-for-bit on the same inputs.
+4. Limit behavior: λ→large recovers degree-$(q-1)$ polynomial fit; edf monotonically
+   decreasing in λ with $q \le \mathrm{edf} \le K$.
+5. Batch-vs-online equivalence: `fit(X)` ≈ `fit(X[:n0])` + `update(X[n0:])` with `forget=0`
+   (Gram updates are exact).
+6. Integration: fit `OnlineStructuredAdditiveDistributionRegressor` with
+   `[InterceptTerm, PSplineTerm]` on simulated heteroskedastic data
+   (e.g. $y \sim N(\sin x, \exp(\cdot))$), check function recovery MSE and that `update` +
+   `predict` run cleanly; run `pytest tests/` for regressions.
+
+## Decisions
+
+- Target only the terms-based estimator; the equation-based `OnlineDistributionalRegression`
+  is untouched.
+- λ handling v1: fixed λ or grid + EDF-based AIC/BIC selection (per term); no REML, no
+  discounted predictive-score selection.
+- Solver: coordinate descent extended with quadratic penalty matrices (enables future mixed
+  L1+spline designs), not a separate direct solver.
+- Support drift: fixed knots from initial fit + linear extrapolation; no automatic boundary
+  expansion or rebasing in v1 (users can pair with `OnlineScaler` to stabilize the domain).
+  Excluded: tensor products, cyclic splines, null-space reparameterization.
+- Tests are internal-consistency only, no R fixtures.
+
+## Further Considerations
+
+1. **Null-space overlap**: with $q = 2$ the penalty leaves a linear trend unpenalized, which
+   overlaps with a `LinearTerm` on the same feature. Recommendation: document it and rely on
+   centering + backfitting in v1 (Option A); alternatively add an optional tiny ridge on the
+   null space (Option B) or full null/range reparameterization (Option C, deferred).
+2. **EDF under backfitting** is per-term (conditional on other terms), not a joint
+   mgcv-style EDF — acceptable for IC-based λ selection, worth noting in docs.
+3. **Knot range safety margin**: knots from the burn-in min/max can be tight; recommend a
+   small configurable padding (e.g. 5% of range) so early online updates don't immediately
+   hit the extrapolation region.
+
+## Roadmap Beyond v1
+
+- **Release 2**: automatic boundary support expansion (append/prepend knots at spacing $h$,
+  initialize new coefficients by difference-extrapolation), discounted online score-based λ
+  selection, edf diagnostics, cyclic P-splines.
+- **Release 3**: periodic approximate REML / GCV refresh, tensor products, shrinkage
+  null-space penalty / term selection.

--- a/docs/terms_and_features.md
+++ b/docs/terms_and_features.md
@@ -48,6 +48,36 @@ Terms are the fundamental building blocks that define different types of relatio
 - `RegularizedLinearTerm`: Linear terms with LASSO/ridge regularization
 - `InterceptTerm`: Simple intercept-only terms
 
+#### Smooth Terms
+- `PSplineTerm`: Univariate penalized B-spline (P-spline) smooths
+
+A `PSplineTerm` fits a smooth function of a single feature using a B-spline basis
+with equidistant knots and a difference penalty on adjacent spline coefficients.
+The penalty strength is either fixed (`lambda_`) or selected over a geometric grid
+by minimizing an information criterion, using the effective degrees of freedom
+$\mathrm{edf}(\lambda) = \mathrm{tr}\big((G + \lambda S)^{-1} G\big)$.
+Knots are fixed from the data range at `fit` time (with configurable relative
+`knot_padding`); predictions beyond the boundary knots use linear extrapolation,
+and online `update` calls reuse the initial knots and centering, so the Gram-matrix
+updates remain exact.
+
+```python
+from ondil.terms import InterceptTerm, PSplineTerm
+
+terms = {
+    0: [InterceptTerm(), PSplineTerm(feature=0, n_splines=20)],
+    1: [InterceptTerm()],
+}
+```
+
+!!! note
+    The term is centered (sum-to-zero) and carries no intercept, so combine it
+    with an `InterceptTerm`. With the default second-order difference penalty,
+    an unpenalized linear trend in the feature remains, which overlaps with a
+    `LinearTerm` on the same feature. The effective degrees of freedom are
+    per-term (conditional on the other terms in the backfitting loop), not a
+    joint mgcv-style EDF.
+
 #### Time Series Terms
 - `TimeSeriesTerm`: Autoregressive terms using lagged features
 - `RegularizedTimeSeriesTerm`: Time series terms with regularization

--- a/examples/pspline_terms.py
+++ b/examples/pspline_terms.py
@@ -1,0 +1,65 @@
+"""
+Online P-spline terms.
+
+This example fits a smooth, heteroskedastic Gaussian model
+
+    y ~ N(sin(2 x), exp(-0.5 + 0.3 x))
+
+using the terms-based OnlineStructuredAdditiveDistributionRegressor with
+penalized B-spline (P-spline) terms for both the mean and the (log-) scale.
+The penalty strength of each term is selected via EDF-based AIC over a
+geometric grid, and the model is then updated online with new data.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from ondil.distributions import Normal
+from ondil.estimators import OnlineStructuredAdditiveDistributionRegressor
+from ondil.terms import InterceptTerm, PSplineTerm
+
+# Simulate heteroskedastic data
+rng = np.random.default_rng(42)
+n = 1000
+x = np.sort(rng.uniform(-2, 2, n))
+mu = np.sin(2 * x)
+sigma = np.exp(-0.5 + 0.3 * x)
+y = mu + sigma * rng.normal(size=n)
+X = x[:, None]
+
+# Batch fit on the first part of the data
+n0 = 750
+estimator = OnlineStructuredAdditiveDistributionRegressor(
+    distribution=Normal(),
+    terms={
+        0: [InterceptTerm(), PSplineTerm(feature=0, n_splines=20, ic="aic")],
+        1: [InterceptTerm(), PSplineTerm(feature=0, n_splines=20, ic="aic")],
+    },
+)
+estimator.fit(X[:n0], y[:n0])
+
+# Online update with the remaining observations
+estimator.update(X[n0:], y[n0:])
+
+# Inspect the fitted smooths
+for param in (0, 1):
+    spline_term = estimator.terms_[param][1]
+    print(
+        f"Parameter {param}: selected lambda = {spline_term.lambda_selected_:.3g}, "
+        f"edf = {spline_term.edf_:.2f}"
+    )
+
+fitted = estimator.predict(X)
+
+fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+axes[0].scatter(x, y, s=5, alpha=0.3, color="grey")
+axes[0].plot(x, mu, label="true $\\mu$", color="black")
+axes[0].plot(x, fitted[:, 0], label="fitted $\\mu$", color="tab:red")
+axes[0].legend()
+axes[0].set_title("Location")
+axes[1].plot(x, sigma, label="true $\\sigma$", color="black")
+axes[1].plot(x, fitted[:, 1], label="fitted $\\sigma$", color="tab:red")
+axes[1].legend()
+axes[1].set_title("Scale")
+fig.tight_layout()
+plt.show()

--- a/src/ondil/coordinate_descent/__init__.py
+++ b/src/ondil/coordinate_descent/__init__.py
@@ -1,6 +1,8 @@
 from .cd_base import (
     online_coordinate_descent,
     online_coordinate_descent_path,
+    online_coordinate_descent_quadratic,
+    online_coordinate_descent_quadratic_path,
 )
 from .cd_linear_constrained import (
     online_linear_constrained_coordinate_descent,
@@ -10,6 +12,8 @@ from .cd_linear_constrained import (
 __all__ = [
     "online_coordinate_descent",
     "online_coordinate_descent_path",
+    "online_coordinate_descent_quadratic",
+    "online_coordinate_descent_quadratic_path",
     "online_linear_constrained_coordinate_descent",
     "online_linear_constrained_coordinate_descent_path",
 ]

--- a/src/ondil/coordinate_descent/cd_base.py
+++ b/src/ondil/coordinate_descent/cd_base.py
@@ -86,6 +86,145 @@ def online_coordinate_descent(
 
 
 @nb.njit()
+def online_coordinate_descent_quadratic(
+    x_gram: np.ndarray,
+    y_gram: np.ndarray,
+    beta: np.ndarray,
+    penalty_matrix: np.ndarray,
+    quadratic_regularization: float,
+    regularization: float,
+    regularization_weights: np.ndarray | None,
+    is_regularized: np.ndarray,
+    alpha: float,
+    beta_lower_bound: np.ndarray | None,
+    beta_upper_bound: np.ndarray | None,
+    selection: Literal["cyclic", "random"] = "cyclic",
+    tolerance: float = 1e-4,
+    max_iterations: int = 1000,
+) -> Tuple[np.ndarray, int]:
+    r"""Coordinate descent with an additional quadratic penalty matrix.
+
+    Solves the penalized weighted least squares problem in Gram form
+
+    $$\min_\beta \tfrac12 \beta^\top (G + \lambda_S S)\beta - h^\top \beta
+    + \text{L1/elastic-net regularization}$$
+
+    by running the standard online coordinate descent on the augmented
+    Gramian $G + \lambda_S S$. With a zero penalty matrix this reduces
+    exactly to `online_coordinate_descent`.
+
+    Args:
+        x_gram (np.ndarray): X-Gramian $$X^TX$$
+        y_gram (np.ndarray): Y-Gramian $$X^TY$$
+        beta (np.ndarray): Current beta vector
+        penalty_matrix (np.ndarray): Quadratic penalty matrix $S$
+        quadratic_regularization (float): Regularization strength $\lambda_S$ for the quadratic penalty
+        regularization (float): L1/elastic-net regularization parameter lambda
+        regularization_weights (np.ndarray | None): Weights for the L1 regularization
+        is_regularized (np.ndarray): Vector of bools indicating whether the coefficient is L1-regularized
+        alpha (float): The elastic net mixing parameter
+        beta_lower_bound (np.ndarray | None): Lower bounds for beta
+        beta_upper_bound (np.ndarray | None): Upper bounds for beta
+        selection (Literal['cyclic', 'random'], optional): Apply cyclic or random coordinate descent. Defaults to "cyclic".
+        tolerance (float, optional): Tolerance for the beta update. Defaults to 1e-4.
+        max_iterations (int, optional): Maximum iterations. Defaults to 1000.
+
+    Returns:
+        Tuple[np.ndarray, int]: Converged $$ \\beta $$ and the iteration count.
+    """
+    a_gram = x_gram + quadratic_regularization * penalty_matrix
+    return online_coordinate_descent(
+        x_gram=a_gram,
+        y_gram=y_gram,
+        beta=beta,
+        regularization=regularization,
+        regularization_weights=regularization_weights,
+        is_regularized=is_regularized,
+        alpha=alpha,
+        beta_lower_bound=beta_lower_bound,
+        beta_upper_bound=beta_upper_bound,
+        selection=selection,
+        tolerance=tolerance,
+        max_iterations=max_iterations,
+    )
+
+
+@nb.njit()
+def online_coordinate_descent_quadratic_path(
+    x_gram: np.ndarray,
+    y_gram: np.ndarray,
+    beta_path: np.ndarray,
+    lambda_path: np.ndarray,
+    penalty_matrix: np.ndarray,
+    is_regularized: np.ndarray,
+    alpha: float,
+    regularization: float,
+    regularization_weights: np.ndarray | None,
+    beta_lower_bound: np.ndarray | None,
+    beta_upper_bound: np.ndarray | None,
+    which_start_value: Literal[
+        "previous_lambda", "previous_fit", "average"
+    ] = "previous_lambda",
+    selection: Literal["cyclic", "random"] = "cyclic",
+    tolerance: float = 1e-4,
+    max_iterations: int = 1000,
+) -> Tuple[np.ndarray, np.ndarray]:
+    r"""Run quadratic-penalty coordinate descent on a grid of penalty strengths.
+
+    For each $\lambda$ in `lambda_path`, solves the Gram-form problem with
+    augmented Gramian $G + \lambda S$, warm-starting via `get_start_beta`.
+    The L1 part (`regularization`, typically 0 for pure quadratic penalties)
+    is held fixed along the path.
+
+    Args:
+        x_gram (np.ndarray): X-Gramian $$X^TX$$
+        y_gram (np.ndarray): Y-Gramian $$X^TY$$
+        beta_path (np.ndarray): The current coefficient path
+        lambda_path (np.ndarray): The grid of quadratic penalty strengths
+        penalty_matrix (np.ndarray): Quadratic penalty matrix $S$
+        is_regularized (np.ndarray): Vector of bools indicating whether the coefficient is L1-regularized
+        alpha (float): The elastic net mixing parameter
+        regularization (float): Fixed L1 regularization parameter (0 disables soft-thresholding)
+        regularization_weights (np.ndarray | None): Weights for the L1 regularization
+        beta_lower_bound (np.ndarray | None): Lower bounds for beta
+        beta_upper_bound (np.ndarray | None): Upper bounds for beta
+        which_start_value (Literal['previous_lambda', 'previous_fit', 'average'], optional): Values to warm-start the coordinate descent. Defaults to "previous_lambda".
+        selection (Literal['cyclic', 'random'], optional): Apply cyclic or random coordinate descent. Defaults to "cyclic".
+        tolerance (float, optional): Tolerance for the beta update. Defaults to 1e-4.
+        max_iterations (int, optional): Maximum iterations. Defaults to 1000.
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: Tuple with the updated coefficient path and the iteration counts.
+    """
+    beta_path_new = np.zeros_like(beta_path)
+    iterations = np.zeros_like(lambda_path)
+
+    if regularization_weights is None:
+        regularization_weights = np.ones(beta_path.shape[1])
+
+    for i, quadratic_regularization in enumerate(lambda_path):
+        beta = get_start_beta(beta_path, beta_path_new, i, which_start_value)
+        beta_path_new[i, :], iterations[i] = online_coordinate_descent_quadratic(
+            x_gram=x_gram,
+            y_gram=y_gram,
+            beta=beta,
+            penalty_matrix=penalty_matrix,
+            quadratic_regularization=quadratic_regularization,
+            regularization=regularization,
+            regularization_weights=regularization_weights,
+            is_regularized=is_regularized,
+            alpha=alpha,
+            beta_lower_bound=beta_lower_bound,
+            beta_upper_bound=beta_upper_bound,
+            selection=selection,
+            tolerance=tolerance,
+            max_iterations=max_iterations,
+        )
+
+    return beta_path_new, iterations
+
+
+@nb.njit()
 def online_coordinate_descent_path(
     x_gram: np.ndarray,
     y_gram: np.ndarray,

--- a/src/ondil/methods/__init__.py
+++ b/src/ondil/methods/__init__.py
@@ -5,6 +5,7 @@ from .linear_constrained import (
     LinearConstrainedCoordinateDescent,
     LinearConstrainedElasticNetPath,
 )
+from .quadratic_penalty import QuadraticPenaltyPath
 from .recursive_least_squares import OrdinaryLeastSquares
 from .ridge import CoordinateDescent, Ridge
 
@@ -17,4 +18,5 @@ __all__ = [
     "LinearConstrainedCoordinateDescent",
     "LinearConstrainedElasticNetPath",
     "CoordinateDescent",
+    "QuadraticPenaltyPath",
 ]

--- a/src/ondil/methods/factory.py
+++ b/src/ondil/methods/factory.py
@@ -4,6 +4,7 @@ from typing import Literal
 from ..base import EstimationMethod
 from .elasticnet import ElasticNetPath
 from .lasso_path import LassoPath
+from .quadratic_penalty import QuadraticPenaltyPath
 from .recursive_least_squares import OrdinaryLeastSquares
 from .ridge import CoordinateDescent
 
@@ -13,7 +14,9 @@ class EstimationMethodFactory:
         pass
 
     @staticmethod
-    def from_string(method: Literal["ols", "lasso", "elasticnet", "ocd"]):
+    def from_string(
+        method: Literal["ols", "lasso", "elasticnet", "ocd", "quadratic_penalty"],
+    ):
         if method == "lasso":
             return LassoPath()
         elif method == "ols":
@@ -22,14 +25,17 @@ class EstimationMethodFactory:
             return ElasticNetPath(alpha=0.5)
         elif method == "ocd":
             return CoordinateDescent()
+        elif method == "quadratic_penalty":
+            return QuadraticPenaltyPath()
         else:
             raise ValueError(
-                "Did not recognize method. Please provide ['ols', 'lasso', 'elasticnet', 'ocd']."
+                "Did not recognize method. Please provide ['ols', 'lasso', 'elasticnet', 'ocd', 'quadratic_penalty']."
             )
 
 
 def get_estimation_method(
-    method: EstimationMethod | Literal["ols", "lasso", "elasticnet", "ocd"],
+    method: EstimationMethod
+    | Literal["ols", "lasso", "elasticnet", "ocd", "quadratic_penalty"],
 ) -> EstimationMethod:
     if isinstance(method, str):
         out = EstimationMethodFactory().from_string(method=method)

--- a/src/ondil/methods/quadratic_penalty.py
+++ b/src/ondil/methods/quadratic_penalty.py
@@ -1,0 +1,212 @@
+from typing import Literal
+
+import numpy as np
+
+from ..base import EstimationMethod
+from ..coordinate_descent import online_coordinate_descent_quadratic_path
+from ..gram import init_gram, init_y_gram, update_gram, update_y_gram
+from ..logging import logger
+
+
+class QuadraticPenaltyPath(EstimationMethod):
+    r"""
+    Path-based estimation with a general quadratic penalty matrix.
+
+    Solves the penalized weighted least squares problem in Gram form
+
+    $$\min_\beta \tfrac12 \beta^\top (G + \lambda S)\beta - h^\top \beta$$
+
+    along a (geometric) decreasing grid of penalty strengths $\lambda$, where $S$ is a
+    user-supplied positive semi-definite penalty matrix (e.g. a P-spline difference
+    penalty $S = D_q^\top D_q$). Coordinate descent is warm-started along the path.
+
+    If a fixed `lambda_` is given, the path collapses to a single value.
+
+    The maximum penalty strength is scaled relative to the data via
+    $\lambda_\max = c \cdot \mathrm{tr}(G) / \mathrm{tr}(S)$ so that the largest
+    penalty effectively enforces the penalty null space, and the lower end of the
+    grid is $\lambda_\min = \lambda_\max \varepsilon_\lambda$.
+
+    We use `numba` to speed up the coordinate descent algorithm.
+    """
+
+    def __init__(
+        self,
+        penalty_matrix: np.ndarray | None = None,
+        lambda_n: int = 50,
+        lambda_eps: float = 1e-12,
+        lambda_max_scale: float = 1e6,
+        lambda_: float | None = None,
+        start_value_initial: Literal[
+            "previous_lambda", "previous_fit", "average"
+        ] = "previous_lambda",
+        start_value_update: Literal[
+            "previous_lambda", "previous_fit", "average"
+        ] = "previous_fit",
+        selection: Literal["cyclic", "random"] = "cyclic",
+        beta_lower_bound: np.ndarray | None = None,
+        beta_upper_bound: np.ndarray | None = None,
+        tolerance: float = 1e-6,
+        max_iterations: int = 1000,
+    ):
+        """
+        Initializes the quadratic penalty path method.
+
+        Args:
+            penalty_matrix (np.ndarray | None): The quadratic penalty matrix $S$. Can also be passed
+                at fit time via `fit_beta_path(..., penalty_matrix=...)`.
+            lambda_n (int): Number of lambda values to use in the path. Default is 50.
+            lambda_eps (float): Minimum lambda value as a fraction of the maximum lambda. Default is 1e-12.
+            lambda_max_scale (float): Scale factor $c$ for the data-driven maximum lambda
+                $\\lambda_\\max = c \\cdot \\mathrm{tr}(G) / \\mathrm{tr}(S)$. Default is 1e6.
+            lambda_ (float | None): Fixed penalty strength. If given, no grid is used. Default is None.
+            start_value_initial (Literal["previous_lambda", "previous_fit", "average"]): Method to initialize the start value for the first fit. Default is "previous_lambda".
+            start_value_update (Literal["previous_lambda", "previous_fit", "average"]): Method to choose the start value on updates. Default is "previous_fit".
+            selection (Literal["cyclic", "random"]): Coordinate selection scheme. Default is "cyclic".
+            beta_lower_bound (np.ndarray | None): Lower bound for the coefficients. Default is None.
+            beta_upper_bound (np.ndarray | None): Upper bound for the coefficients. Default is None.
+            tolerance (float): Tolerance for the optimization. Default is 1e-6.
+            max_iterations (int): Maximum number of iterations for the optimization. Default is 1000.
+        """
+        super().__init__(
+            _path_based_method=True,
+            _accepts_bounds=True,
+            _accepts_selection=True,
+        )
+        self.penalty_matrix = penalty_matrix
+        self.lambda_n = lambda_n
+        self.lambda_eps = lambda_eps
+        self.lambda_max_scale = lambda_max_scale
+        self.lambda_ = lambda_
+        self.start_value_initial = start_value_initial
+        self.start_value_update = start_value_update
+        self.selection = selection
+        self.beta_lower_bound = beta_lower_bound
+        self.beta_upper_bound = beta_upper_bound
+        self.tolerance = tolerance
+        self.max_iterations = max_iterations
+        self._path_length = 1 if lambda_ is not None else lambda_n
+
+    def make_lambda_path(
+        self,
+        x_gram: np.ndarray,
+        penalty_matrix: np.ndarray | None = None,
+    ) -> np.ndarray:
+        """Construct the (geometrically decreasing) grid of penalty strengths."""
+        if self.lambda_ is not None:
+            return np.array([float(self.lambda_)])
+        penalty_matrix = (
+            penalty_matrix if penalty_matrix is not None else self.penalty_matrix
+        )
+        if penalty_matrix is None:
+            raise ValueError("No penalty matrix provided.")
+        trace_penalty = np.trace(penalty_matrix)
+        if np.isclose(trace_penalty, 0.0):
+            raise ValueError("Penalty matrix has zero trace.")
+        lambda_max = self.lambda_max_scale * np.trace(x_gram) / trace_penalty
+        if not np.isfinite(lambda_max) or lambda_max <= 0:
+            lambda_max = 1.0
+        return np.geomspace(lambda_max, lambda_max * self.lambda_eps, self.lambda_n)
+
+    @staticmethod
+    def effective_degrees_of_freedom(
+        x_gram: np.ndarray,
+        penalty_matrix: np.ndarray,
+        lambda_path: np.ndarray,
+    ) -> np.ndarray:
+        r"""Compute the effective degrees of freedom for each penalty strength.
+
+        $$\mathrm{edf}(\lambda) = \mathrm{tr}\big((G + \lambda S)^{-1} G\big)$$
+        """
+        edf = np.empty(lambda_path.shape[0])
+        for i, lam in enumerate(lambda_path):
+            edf[i] = np.trace(np.linalg.solve(x_gram + lam * penalty_matrix, x_gram))
+        return edf
+
+    @staticmethod
+    def init_x_gram(X, weights, forget):
+        return init_gram(X=X, w=weights, forget=forget)
+
+    @staticmethod
+    def init_y_gram(X, y, weights, forget):
+        return init_y_gram(X, y, w=weights, forget=forget)
+
+    @staticmethod
+    def update_x_gram(gram, X, weights, forget):
+        return update_gram(gram, X, w=weights, forget=forget)
+
+    @staticmethod
+    def update_y_gram(gram, X, y, weights, forget):
+        return update_y_gram(gram, X, y, forget=forget, w=weights)
+
+    def _fit_path(
+        self,
+        x_gram: np.ndarray,
+        y_gram: np.ndarray,
+        beta_path: np.ndarray,
+        is_regularized: np.ndarray,
+        which_start_value: str,
+        **kwargs,
+    ) -> np.ndarray:
+        logger.debug(f"Got following kwargs: {[*kwargs.keys()]}")
+        penalty_matrix = kwargs.get("penalty_matrix", self.penalty_matrix)
+        if penalty_matrix is None:
+            raise ValueError("No penalty matrix provided.")
+
+        beta_lower_bound = kwargs.get("beta_lower_bound", self.beta_lower_bound)
+        beta_upper_bound = kwargs.get("beta_upper_bound", self.beta_upper_bound)
+
+        lambda_path = self.make_lambda_path(
+            x_gram=x_gram, penalty_matrix=penalty_matrix
+        )
+        self.lambda_path_ = lambda_path
+
+        beta_path, _ = online_coordinate_descent_quadratic_path(
+            x_gram=x_gram,
+            y_gram=y_gram.squeeze(-1),
+            beta_path=beta_path,
+            lambda_path=lambda_path,
+            penalty_matrix=penalty_matrix,
+            is_regularized=is_regularized,
+            alpha=1.0,
+            regularization=0.0,
+            regularization_weights=None,
+            beta_lower_bound=beta_lower_bound,
+            beta_upper_bound=beta_upper_bound,
+            which_start_value=which_start_value,
+            selection=self.selection,
+            tolerance=self.tolerance,
+            max_iterations=self.max_iterations,
+        )
+        return beta_path
+
+    def fit_beta_path(self, x_gram, y_gram, is_regularized, **kwargs):
+        beta_path = np.zeros((self._path_length, x_gram.shape[0]))
+        return self._fit_path(
+            x_gram=x_gram,
+            y_gram=y_gram,
+            beta_path=beta_path,
+            is_regularized=is_regularized,
+            which_start_value=self.start_value_initial,
+            **kwargs,
+        )
+
+    def update_beta_path(self, x_gram, y_gram, beta_path, is_regularized, **kwargs):
+        return self._fit_path(
+            x_gram=x_gram,
+            y_gram=y_gram,
+            beta_path=beta_path,
+            is_regularized=is_regularized,
+            which_start_value=self.start_value_update,
+            **kwargs,
+        )
+
+    def fit_beta(self, x_gram, y_gram, **kwargs):
+        raise NotImplementedError(
+            "QuadraticPenaltyPath is a path-based method. Use fit_beta_path."
+        )
+
+    def update_beta(self, x_gram, y_gram, beta, **kwargs):
+        raise NotImplementedError(
+            "QuadraticPenaltyPath is a path-based method. Use update_beta_path."
+        )

--- a/src/ondil/terms/__init__.py
+++ b/src/ondil/terms/__init__.py
@@ -13,6 +13,7 @@ from .linear import (
     RegularizedLinearTerm,
 )
 from .special import ScikitLearnEstimatorTerm
+from .splines import PSplineTerm
 from .time_series import (
     RegularizedTimeSeriesTerm,
     TimeSeriesTerm,
@@ -24,6 +25,7 @@ __all__ = [
     "LinearTerm",
     "RegularizedLinearTerm",
     "InterceptTerm",
+    "PSplineTerm",
     "LaggedResidual",
     "LaggedSquaredResidual",
     "LaggedAbsoluteResidual",

--- a/src/ondil/terms/splines.py
+++ b/src/ondil/terms/splines.py
@@ -1,0 +1,524 @@
+import copy
+from dataclasses import dataclass, replace
+from typing import Literal
+
+import numpy as np
+from scipy.interpolate import BSpline
+
+from ..base import Distribution, Term
+from ..gram import init_forget_vector
+from ..information_criteria import InformationCriterion
+from ..methods import get_estimation_method
+from ..methods.quadratic_penalty import QuadraticPenaltyPath
+from ..utils import calculate_effective_training_length
+
+
+def make_bspline_knots(
+    x_min: float,
+    x_max: float,
+    n_splines: int,
+    degree: int,
+    padding: float = 0.0,
+) -> np.ndarray:
+    r"""Construct an equidistant B-spline knot vector.
+
+    The knot vector has `n_splines + degree + 1` equidistant knots such that
+    the domain `[x_min - pad, x_max + pad]` is covered by `n_splines` basis
+    functions of the given degree, where `pad = padding * (x_max - x_min)`.
+
+    Args:
+        x_min (float): Lower end of the data range.
+        x_max (float): Upper end of the data range.
+        n_splines (int): Number of B-spline basis functions $K$.
+        degree (int): Degree of the B-spline basis $p$.
+        padding (float): Relative padding of the data range. Defaults to 0.0.
+
+    Returns:
+        np.ndarray: Knot vector of length $K + p + 1$.
+    """
+    if n_splines <= degree:
+        raise ValueError("n_splines must be larger than the spline degree.")
+    data_range = x_max - x_min
+    if data_range <= 0:
+        raise ValueError("Feature has zero range; cannot construct spline basis.")
+    pad = padding * data_range
+    lower = x_min - pad
+    upper = x_max + pad
+    step = (upper - lower) / (n_splines - degree)
+    return lower + step * np.arange(-degree, n_splines + 1)
+
+
+def make_bspline_basis(
+    x: np.ndarray,
+    knots: np.ndarray,
+    degree: int,
+) -> np.ndarray:
+    r"""Evaluate the B-spline basis with linear extrapolation outside the boundary knots.
+
+    Inside the domain `[knots[degree], knots[-degree - 1]]` the basis is evaluated
+    via `scipy.interpolate.BSpline.design_matrix`. Outside the domain, each basis
+    function is extrapolated linearly from its value and first derivative at the
+    nearest boundary (mgcv `bs="ps"` behavior).
+
+    Args:
+        x (np.ndarray): Points at which to evaluate the basis.
+        knots (np.ndarray): Full knot vector.
+        degree (int): Degree of the B-spline basis.
+
+    Returns:
+        np.ndarray: Basis matrix of shape `(len(x), len(knots) - degree - 1)`.
+    """
+    x = np.asarray(x, dtype=float).reshape(-1)
+    n_splines = knots.shape[0] - degree - 1
+    lower = knots[degree]
+    upper = knots[-degree - 1]
+
+    basis = np.zeros((x.shape[0], n_splines))
+    inside = (x >= lower) & (x <= upper)
+    if np.any(inside):
+        basis[inside, :] = BSpline.design_matrix(x[inside], knots, degree).toarray()
+
+    for mask, boundary in ((x < lower, lower), (x > upper, upper)):
+        if np.any(mask):
+            spline = BSpline(knots, np.eye(n_splines), degree)
+            value = spline(boundary)
+            slope = spline.derivative()(boundary)
+            basis[mask, :] = (
+                value[None, :] + (x[mask, None] - boundary) * slope[None, :]
+            )
+
+    return basis
+
+
+def make_difference_penalty(
+    n_splines: int,
+    diff_order: int,
+    normalize: bool = True,
+) -> np.ndarray:
+    r"""Construct the P-spline difference penalty matrix $S = D_q^\top D_q$.
+
+    Args:
+        n_splines (int): Number of B-spline coefficients $K$.
+        diff_order (int): Order $q$ of the difference operator.
+        normalize (bool): Normalize $S$ by its Frobenius norm so that the
+            penalty strength has comparable meaning across terms. Defaults to True.
+
+    Returns:
+        np.ndarray: Penalty matrix of shape `(K, K)`.
+    """
+    if not 0 < diff_order < n_splines:
+        raise ValueError("diff_order must be in (0, n_splines).")
+    diff = np.diff(np.eye(n_splines), n=diff_order, axis=0)
+    penalty = diff.T @ diff
+    if normalize:
+        penalty = penalty / np.linalg.norm(penalty)
+    return penalty
+
+
+def make_centering_constraint(column_means: np.ndarray) -> np.ndarray:
+    r"""Construct the sum-to-zero constraint reparameterization matrix.
+
+    For the constraint $m^\top \beta = 0$ (with $m$ the weighted column means of
+    the basis, i.e. the fitted values have zero weighted mean), returns an
+    orthonormal basis $Z$ of the null space of $m^\top$ such that $\beta = Z\gamma$.
+    This removes the constant component of the smooth, avoiding identifiability
+    clashes with an intercept, and renders the penalized Gramian nonsingular.
+
+    Args:
+        column_means (np.ndarray): Weighted column means $m$ of the basis matrix.
+
+    Returns:
+        np.ndarray: Constraint matrix of shape `(K, K - 1)`.
+    """
+    q, _ = np.linalg.qr(column_means[:, None], mode="complete")
+    return q[:, 1:]
+
+
+def make_demmler_reinsch_transform(
+    gram: np.ndarray,
+    penalty: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    r"""Construct the Demmler-Reinsch reparameterization.
+
+    Finds a transformation $T$ such that, for coefficients $\beta = T\gamma$,
+    the Gramian becomes the identity, $T^\top G T = I$, and the penalty becomes
+    diagonal, $T^\top S T = \mathrm{diag}(\Lambda)$ with $\Lambda \ge 0$. In this
+    parameterization the penalized Gramian $I + \lambda\,\mathrm{diag}(\Lambda)$
+    is perfectly conditioned for coordinate descent at any penalty strength.
+
+    Args:
+        gram (np.ndarray): The (weighted) Gramian $G$ of the design matrix.
+        penalty (np.ndarray): The penalty matrix $S$.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: The transformation matrix $T$ and the
+            penalty eigenvalues $\Lambda$.
+    """
+    eigenvalues_gram, eigenvectors_gram = np.linalg.eigh(gram)
+    eigenvalues_gram = np.maximum(eigenvalues_gram, np.max(eigenvalues_gram) * 1e-10)
+    inverse_sqrt = eigenvectors_gram / np.sqrt(eigenvalues_gram)
+    middle = inverse_sqrt.T @ penalty @ inverse_sqrt
+    eigenvalues, eigenvectors = np.linalg.eigh(middle)
+    eigenvalues = np.clip(eigenvalues, 0.0, None)
+    transform = inverse_sqrt @ eigenvectors
+    return transform, eigenvalues
+
+
+@dataclass(frozen=True)
+class PSplineTermState:
+    knots: np.ndarray | None
+    column_means: np.ndarray | None
+    transform: np.ndarray | None
+    penalty_eigenvalues: np.ndarray | None
+    g: np.ndarray | None
+    h: np.ndarray | None
+    coef_path_: np.ndarray | None
+    lambda_grid: np.ndarray | None
+    edf_: np.ndarray | None
+    ic_values_: np.ndarray | None
+    best_idx: int | None
+    coef_: np.ndarray | None
+    rss: np.ndarray | None
+    n_observations: int | None
+
+
+class PSplineTerm(Term):
+    r"""Univariate penalized B-spline (P-spline) term.
+
+    Fits a smooth function of a single feature using a B-spline basis with
+    equidistant knots and a difference penalty $S = D_q^\top D_q$ on adjacent
+    spline coefficients. The penalty strength $\lambda$ is either fixed or
+    selected over a geometric grid by minimizing an information criterion with
+    effective degrees of freedom
+    $\mathrm{edf}(\lambda) = \mathrm{tr}\big((G + \lambda S)^{-1} G\big)$.
+
+    Knots are fixed from the data range at `fit` time (with configurable
+    relative padding); predictions beyond the boundary knots use linear
+    extrapolation. Identifiability is ensured by a sum-to-zero constraint on
+    the fitted values: the weighted column means of the basis (stored at fit
+    time) define the constraint $m^\top\beta = 0$, which is absorbed by an
+    orthonormal reparameterization with $K - 1$ coefficients. The term thus
+    carries no intercept and does not clash with an `InterceptTerm` in the
+    backfitting loop. On top of the constraint, a Demmler-Reinsch
+    reparameterization (fixed at fit time) renders the Gramian (approximately)
+    the identity and the penalty diagonal, so the coordinate descent solver is
+    well conditioned at any penalty strength.
+
+    !!! note
+        With `diff_order=2` the penalty leaves a linear trend in the feature
+        unpenalized, which overlaps with a `LinearTerm` on the same feature.
+        The effective degrees of freedom are per-term (conditional on the other
+        terms), not a joint mgcv-style EDF.
+    """
+
+    allow_online_updates: bool = True
+
+    def __init__(
+        self,
+        feature: int,
+        n_splines: int = 20,
+        degree: int = 3,
+        diff_order: int = 2,
+        lambda_: float | None = None,
+        lambda_n: int = 50,
+        lambda_eps: float = 1e-12,
+        ic: Literal["aic", "bic", "aicc", "hqc", "max"] = "aic",
+        forget: float = 0.0,
+        knot_padding: float = 0.05,
+        method: QuadraticPenaltyPath | None = None,
+    ):
+        """
+        Args:
+            feature (int): Column index of the feature to smooth.
+            n_splines (int): Number of B-spline basis functions. Defaults to 20.
+            degree (int): Degree of the B-spline basis. Defaults to 3 (cubic).
+            diff_order (int): Order of the difference penalty. Defaults to 2.
+            lambda_ (float | None): Fixed penalty strength. If None, the strength
+                is selected over a grid via the information criterion. Defaults to None.
+            lambda_n (int): Number of grid points for the penalty strength. Defaults to 50.
+            lambda_eps (float): Ratio of smallest to largest grid value. Defaults to 1e-12.
+            ic (Literal["aic", "bic", "aicc", "hqc", "max"]): Information criterion
+                for the selection of the penalty strength. Defaults to "aic".
+            forget (float): Forgetting factor for online updates. Defaults to 0.0.
+            knot_padding (float): Relative padding of the data range used for knot
+                placement, guarding against early online updates hitting the
+                extrapolation region. Defaults to 0.05.
+            method (QuadraticPenaltyPath | None): Estimation method instance.
+                If None, a `QuadraticPenaltyPath` is created from the lambda
+                parameters above. Defaults to None.
+        """
+        self.feature = feature
+        self.n_splines = n_splines
+        self.degree = degree
+        self.diff_order = diff_order
+        self.lambda_ = lambda_
+        self.lambda_n = lambda_n
+        self.lambda_eps = lambda_eps
+        self.ic = ic
+        self.forget = forget
+        self.knot_padding = knot_padding
+        if method is None:
+            method = QuadraticPenaltyPath(
+                lambda_n=lambda_n,
+                lambda_eps=lambda_eps,
+                lambda_=lambda_,
+            )
+        self.method = method
+
+    def _prepare_term(self):
+        self._method = get_estimation_method(self.method)
+        if not isinstance(self._method, QuadraticPenaltyPath):
+            raise ValueError("PSplineTerm requires a QuadraticPenaltyPath method.")
+        return self
+
+    @property
+    def coef_(self) -> np.ndarray:
+        if not hasattr(self, "_state"):
+            raise AttributeError("The term has not been fitted yet.")
+        return self._state.coef_
+
+    @property
+    def edf_(self) -> float:
+        """Effective degrees of freedom of the selected fit."""
+        if not hasattr(self, "_state"):
+            raise AttributeError("The term has not been fitted yet.")
+        return float(self._state.edf_[self._state.best_idx])
+
+    @property
+    def lambda_selected_(self) -> float:
+        """Selected penalty strength."""
+        if not hasattr(self, "_state"):
+            raise AttributeError("The term has not been fitted yet.")
+        return float(self._state.lambda_grid[self._state.best_idx])
+
+    def make_penalty_matrix(self) -> np.ndarray:
+        """Construct the (diagonal) penalty matrix in the fitted parameterization."""
+        if not hasattr(self, "_state"):
+            raise AttributeError("The term has not been fitted yet.")
+        return np.diag(self._state.penalty_eigenvalues)
+
+    def _make_basis(self, X: np.ndarray, knots: np.ndarray) -> np.ndarray:
+        x = np.asarray(X)[:, self.feature]
+        return make_bspline_basis(x=x, knots=knots, degree=self.degree)
+
+    def make_design_matrix(self, X: np.ndarray) -> np.ndarray:
+        """Create the reparameterized B-spline design matrix using the fitted knots and transform."""
+        if not hasattr(self, "_state"):
+            raise AttributeError("The term has not been fitted yet.")
+        return self._make_basis(X, self._state.knots) @ self._state.transform
+
+    def make_design_matrix_in_sample_during_fit(self, X: np.ndarray, **kwargs):
+        return self.make_design_matrix(X)
+
+    def make_design_matrix_in_sample_during_update(self, X: np.ndarray, **kwargs):
+        return self.make_design_matrix(X)
+
+    def make_design_matrix_out_of_sample(self, X: np.ndarray, **kwargs):
+        return self.make_design_matrix(X)
+
+    def _model_selection(
+        self,
+        g: np.ndarray,
+        h: np.ndarray,
+        coef_path_: np.ndarray,
+        penalty: np.ndarray,
+        lambda_grid: np.ndarray,
+        rss: np.ndarray,
+        n_observations: int,
+    ):
+        edf_ = self._method.effective_degrees_of_freedom(
+            x_gram=g,
+            penalty_matrix=penalty,
+            lambda_path=lambda_grid,
+        )
+        n_effective = calculate_effective_training_length(self.forget, n_observations)
+        ic_values_ = InformationCriterion(
+            n_observations=n_effective,
+            n_parameters=edf_,
+            criterion=self.ic,
+        ).from_rss(rss)
+        best_idx = int(np.argmin(ic_values_))
+        return edf_, ic_values_, best_idx
+
+    def fit(
+        self,
+        X: np.ndarray,
+        y: np.ndarray,
+        fitted_values: np.ndarray,
+        target_values: np.ndarray,
+        distribution: Distribution,
+        sample_weight: np.ndarray,
+        estimation_weight: np.ndarray,
+    ) -> "PSplineTerm":
+        """Fit the P-spline term on the working vector `y`."""
+        x = np.asarray(X)[:, self.feature]
+        knots = make_bspline_knots(
+            x_min=float(np.min(x)),
+            x_max=float(np.max(x)),
+            n_splines=self.n_splines,
+            degree=self.degree,
+            padding=self.knot_padding,
+        )
+        basis = make_bspline_basis(x=x, knots=knots, degree=self.degree)
+
+        forget_weights = init_forget_vector(self.forget, y.shape[0])
+        column_means = np.average(basis, weights=sample_weight * forget_weights, axis=0)
+        constraint = make_centering_constraint(column_means)
+
+        # Demmler-Reinsch reparameterization of the constrained basis:
+        # identity Gramian, diagonal penalty.
+        gram_constrained = self._method.init_x_gram(
+            X=basis @ constraint,
+            weights=sample_weight * estimation_weight,
+            forget=self.forget,
+        )
+        penalty_constrained = (
+            constraint.T
+            @ make_difference_penalty(
+                n_splines=self.n_splines,
+                diff_order=self.diff_order,
+            )
+            @ constraint
+        )
+        transform_dr, penalty_eigenvalues = make_demmler_reinsch_transform(
+            gram=gram_constrained,
+            penalty=penalty_constrained,
+        )
+        transform = constraint @ transform_dr
+        X_mat = basis @ transform
+
+        penalty = np.diag(penalty_eigenvalues)
+        is_regularized = np.zeros(X_mat.shape[1], dtype=np.bool_)
+
+        g = self._method.init_x_gram(
+            X=X_mat,
+            weights=sample_weight * estimation_weight,
+            forget=self.forget,
+        )
+        h = self._method.init_y_gram(
+            X=X_mat,
+            y=y,
+            weights=sample_weight * estimation_weight,
+            forget=self.forget,
+        )
+        coef_path_ = self._method.fit_beta_path(
+            x_gram=g,
+            y_gram=h,
+            is_regularized=is_regularized,
+            penalty_matrix=penalty,
+        )
+        lambda_grid = self._method.lambda_path_
+
+        n_observations = y.shape[0]
+        residuals = y[:, None] - X_mat @ coef_path_.T
+        rss = np.sum((residuals**2) * (sample_weight * forget_weights)[:, None], axis=0)
+        rss = rss / np.mean(sample_weight * forget_weights)
+
+        edf_, ic_values_, best_idx = self._model_selection(
+            g=g,
+            h=h,
+            coef_path_=coef_path_,
+            penalty=penalty,
+            lambda_grid=lambda_grid,
+            rss=rss,
+            n_observations=n_observations,
+        )
+
+        self._state = PSplineTermState(
+            knots=knots,
+            column_means=column_means,
+            transform=transform,
+            penalty_eigenvalues=penalty_eigenvalues,
+            g=g,
+            h=h,
+            coef_path_=coef_path_,
+            lambda_grid=lambda_grid,
+            edf_=edf_,
+            ic_values_=ic_values_,
+            best_idx=best_idx,
+            coef_=coef_path_[best_idx, :],
+            rss=rss,
+            n_observations=n_observations,
+        )
+        return self
+
+    def update(
+        self,
+        X: np.ndarray,
+        y: np.ndarray,
+        fitted_values: np.ndarray,
+        target_values: np.ndarray,
+        distribution: Distribution,
+        sample_weight: np.ndarray,
+        estimation_weight: np.ndarray,
+    ) -> "PSplineTerm":
+        """Update the P-spline term with new data, keeping knots and constraint fixed."""
+        X_mat = self.make_design_matrix(X)
+        penalty = self.make_penalty_matrix()
+        is_regularized = np.zeros(X_mat.shape[1], dtype=np.bool_)
+
+        g = self._method.update_x_gram(
+            gram=self._state.g,
+            X=X_mat,
+            weights=sample_weight * estimation_weight,
+            forget=self.forget,
+        )
+        h = self._method.update_y_gram(
+            gram=self._state.h,
+            X=X_mat,
+            y=y,
+            weights=sample_weight * estimation_weight,
+            forget=self.forget,
+        )
+        coef_path_ = self._method.update_beta_path(
+            x_gram=g,
+            y_gram=h,
+            beta_path=self._state.coef_path_,
+            is_regularized=is_regularized,
+            penalty_matrix=penalty,
+        )
+        lambda_grid = self._method.lambda_path_
+
+        n_observations = self._state.n_observations + y.shape[0]
+        forget_weights = init_forget_vector(self.forget, y.shape[0])
+        residuals = y[:, None] - X_mat @ coef_path_.T
+        rss_new = np.sum(
+            (residuals**2) * (sample_weight * forget_weights)[:, None], axis=0
+        )
+        rss_new = rss_new / np.mean(sample_weight * forget_weights)
+        rss = (1 - self.forget) ** y.shape[0] * self._state.rss + rss_new
+
+        edf_, ic_values_, best_idx = self._model_selection(
+            g=g,
+            h=h,
+            coef_path_=coef_path_,
+            penalty=penalty,
+            lambda_grid=lambda_grid,
+            rss=rss,
+            n_observations=n_observations,
+        )
+
+        new_instance = copy.copy(self)
+        new_instance._state = replace(
+            self._state,
+            g=g,
+            h=h,
+            coef_path_=coef_path_,
+            lambda_grid=lambda_grid,
+            edf_=edf_,
+            ic_values_=ic_values_,
+            best_idx=best_idx,
+            coef_=coef_path_[best_idx, :],
+            rss=rss,
+            n_observations=n_observations,
+        )
+        return new_instance
+
+    def predict_out_of_sample(
+        self,
+        X: np.ndarray,
+        distribution: Distribution,
+    ) -> np.ndarray:
+        """Predict the smooth contribution for new data."""
+        X_mat = self.make_design_matrix(X)
+        return X_mat @ self._state.coef_

--- a/tests/test_terms_pspline.py
+++ b/tests/test_terms_pspline.py
@@ -1,0 +1,419 @@
+import numpy as np
+import pytest
+
+from ondil.coordinate_descent import (
+    online_coordinate_descent,
+    online_coordinate_descent_quadratic,
+    online_coordinate_descent_quadratic_path,
+)
+from ondil.distributions import Normal
+from ondil.estimators import OnlineStructuredAdditiveDistributionRegressor
+from ondil.gram import init_gram, init_y_gram
+from ondil.methods import QuadraticPenaltyPath
+from ondil.terms import InterceptTerm, PSplineTerm
+from ondil.terms.splines import (
+    make_bspline_basis,
+    make_bspline_knots,
+    make_centering_constraint,
+    make_demmler_reinsch_transform,
+    make_difference_penalty,
+)
+
+N_SPLINES = 12
+DEGREE = 3
+DIFF_ORDER = 2
+
+
+def _make_term_inputs(n):
+    distribution = Normal()
+    fitted_values = np.tile([0.0, 1.0], (n, 1))
+    sample_weight = np.ones(n)
+    estimation_weight = np.ones(n)
+    return distribution, fitted_values, sample_weight, estimation_weight
+
+
+# ----------------------------------------------------------------------------
+# Phase 1: Basis & penalty
+# ----------------------------------------------------------------------------
+
+
+def test_basis_shape_and_partition_of_unity():
+    rng = np.random.default_rng(1)
+    x = rng.uniform(0, 10, 500)
+    knots = make_bspline_knots(0.0, 10.0, N_SPLINES, DEGREE)
+    basis = make_bspline_basis(x, knots, DEGREE)
+    assert basis.shape == (500, N_SPLINES)
+    # Partition of unity inside the domain
+    np.testing.assert_allclose(basis.sum(axis=1), 1.0, atol=1e-12)
+    assert np.all(basis >= 0)
+
+
+def test_basis_linear_extrapolation():
+    knots = make_bspline_knots(0.0, 1.0, N_SPLINES, DEGREE)
+    rng = np.random.default_rng(2)
+    coef = rng.normal(size=N_SPLINES)
+
+    # Three equally spaced points beyond each boundary: exact collinearity
+    for x_out in (np.array([-0.3, -0.2, -0.1]), np.array([1.1, 1.2, 1.3])):
+        basis = make_bspline_basis(x_out, knots, DEGREE)
+        f = basis @ coef
+        np.testing.assert_allclose(f[1], (f[0] + f[2]) / 2, atol=1e-12)
+
+    # Continuity of value and slope at the boundary
+    eps = 1e-6
+    for boundary, sign in ((0.0, -1.0), (1.0, 1.0)):
+        x_eval = np.array([boundary, boundary + sign * eps])
+        basis = make_bspline_basis(x_eval, knots, DEGREE)
+        f = basis @ coef
+        np.testing.assert_allclose(f[1], f[0], atol=1e-4)
+
+
+def test_penalty_annihilates_polynomials_and_banded():
+    penalty = make_difference_penalty(N_SPLINES, DIFF_ORDER)
+    # S is symmetric PSD with Frobenius norm 1
+    np.testing.assert_allclose(penalty, penalty.T)
+    np.testing.assert_allclose(np.linalg.norm(penalty), 1.0)
+    # Annihilates polynomial coefficient sequences up to degree q - 1
+    idx = np.arange(N_SPLINES, dtype=float)
+    for power in range(DIFF_ORDER):
+        np.testing.assert_allclose(penalty @ idx**power, 0.0, atol=1e-12)
+    # Bandedness: zero outside |i - j| > q
+    i, j = np.meshgrid(idx, idx, indexing="ij")
+    assert np.all(penalty[np.abs(i - j) > DIFF_ORDER] == 0)
+
+
+# ----------------------------------------------------------------------------
+# Phase 2: Solver
+# ----------------------------------------------------------------------------
+
+
+def _make_gram_problem(seed=42, n=200, k=N_SPLINES):
+    rng = np.random.default_rng(seed)
+    x = rng.uniform(0, 1, n)
+    knots = make_bspline_knots(0.0, 1.0, k, DEGREE)
+    X = make_bspline_basis(x, knots, DEGREE)
+    y = np.sin(2 * np.pi * x) + rng.normal(0, 0.1, n)
+    w = np.ones(n)
+    g = init_gram(X, w, 0.0)
+    h = init_y_gram(X, y, w, 0.0).squeeze(-1)
+    return g, h
+
+
+def test_quadratic_cd_matches_direct_solve():
+    g, h = _make_gram_problem()
+    penalty = make_difference_penalty(N_SPLINES, DIFF_ORDER)
+    is_regularized = np.zeros(N_SPLINES, dtype=np.bool_)
+    for lam in [1e-4, 1e-1, 1e2, 1e5]:
+        beta_cd, _ = online_coordinate_descent_quadratic(
+            x_gram=g,
+            y_gram=h,
+            beta=np.zeros(N_SPLINES),
+            penalty_matrix=penalty,
+            quadratic_regularization=lam,
+            regularization=0.0,
+            regularization_weights=None,
+            is_regularized=is_regularized,
+            alpha=1.0,
+            beta_lower_bound=None,
+            beta_upper_bound=None,
+            tolerance=1e-12,
+            max_iterations=100_000,
+        )
+        beta_direct = np.linalg.solve(g + lam * penalty, h)
+        np.testing.assert_allclose(beta_cd, beta_direct, atol=1e-4)
+
+
+def test_quadratic_cd_with_zero_penalty_matches_plain_cd():
+    g, h = _make_gram_problem()
+    is_regularized = np.ones(N_SPLINES, dtype=np.bool_)
+    zero_penalty = np.zeros((N_SPLINES, N_SPLINES))
+    for l1 in [0.0, 0.5, 5.0]:
+        beta_quad, _ = online_coordinate_descent_quadratic(
+            x_gram=g,
+            y_gram=h,
+            beta=np.zeros(N_SPLINES),
+            penalty_matrix=zero_penalty,
+            quadratic_regularization=123.0,
+            regularization=l1,
+            regularization_weights=None,
+            is_regularized=is_regularized,
+            alpha=1.0,
+            beta_lower_bound=None,
+            beta_upper_bound=None,
+        )
+        beta_plain, _ = online_coordinate_descent(
+            x_gram=g,
+            y_gram=h,
+            beta=np.zeros(N_SPLINES),
+            regularization=l1,
+            regularization_weights=None,
+            is_regularized=is_regularized,
+            alpha=1.0,
+            beta_lower_bound=None,
+            beta_upper_bound=None,
+        )
+        np.testing.assert_array_equal(beta_quad, beta_plain)
+
+
+def test_quadratic_cd_path_warm_start():
+    # Use the Demmler-Reinsch parameterization (as PSplineTerm does), where the
+    # Gramian is the identity and the penalty diagonal, so coordinate descent
+    # is well conditioned along the whole path.
+    rng = np.random.default_rng(42)
+    n = 200
+    x = rng.uniform(0, 1, n)
+    knots = make_bspline_knots(0.0, 1.0, N_SPLINES, DEGREE)
+    basis = make_bspline_basis(x, knots, DEGREE)
+    y = np.sin(2 * np.pi * x) + rng.normal(0, 0.1, n)
+    constraint = make_centering_constraint(basis.mean(axis=0))
+    gram_constrained = init_gram(basis @ constraint, np.ones(n), 0.0)
+    penalty_constrained = (
+        constraint.T @ make_difference_penalty(N_SPLINES, DIFF_ORDER) @ constraint
+    )
+    transform, eigenvalues = make_demmler_reinsch_transform(
+        gram_constrained, penalty_constrained
+    )
+    X = basis @ constraint @ transform
+    g = init_gram(X, np.ones(n), 0.0)
+    h = init_y_gram(X, y, np.ones(n), 0.0).squeeze(-1)
+    penalty = np.diag(eigenvalues)
+    k = X.shape[1]
+
+    lambda_path = np.geomspace(1e10, 1e-10, 25)
+    beta_path, _ = online_coordinate_descent_quadratic_path(
+        x_gram=g,
+        y_gram=h,
+        beta_path=np.zeros((25, k)),
+        lambda_path=lambda_path,
+        penalty_matrix=penalty,
+        is_regularized=np.zeros(k, dtype=np.bool_),
+        alpha=1.0,
+        regularization=0.0,
+        regularization_weights=None,
+        beta_lower_bound=None,
+        beta_upper_bound=None,
+        tolerance=1e-12,
+        max_iterations=10_000,
+    )
+    for i, lam in enumerate(lambda_path):
+        np.testing.assert_allclose(
+            beta_path[i], np.linalg.solve(g + lam * penalty, h), atol=1e-8
+        )
+
+
+def test_edf_monotone_and_bounded():
+    g, _ = _make_gram_problem()
+    penalty = make_difference_penalty(N_SPLINES, DIFF_ORDER)
+    lambda_path = np.geomspace(1e8, 1e-8, 40)
+    edf = QuadraticPenaltyPath.effective_degrees_of_freedom(g, penalty, lambda_path)
+    # decreasing lambda -> increasing edf
+    assert np.all(np.diff(edf) >= -1e-8)
+    assert np.all(edf >= DIFF_ORDER - 1e-6)
+    assert np.all(edf <= N_SPLINES + 1e-6)
+
+
+def test_large_lambda_recovers_polynomial():
+    g, h = _make_gram_problem()
+    penalty = make_difference_penalty(N_SPLINES, DIFF_ORDER)
+    lam = 1e10 * np.trace(g) / np.trace(penalty)
+    beta = np.linalg.solve(g + lam * penalty, h)
+    beta_cd, _ = online_coordinate_descent_quadratic(
+        x_gram=g,
+        y_gram=h,
+        beta=np.zeros(N_SPLINES),
+        penalty_matrix=penalty,
+        quadratic_regularization=lam,
+        regularization=0.0,
+        regularization_weights=None,
+        is_regularized=np.zeros(N_SPLINES, dtype=np.bool_),
+        alpha=1.0,
+        beta_lower_bound=None,
+        beta_upper_bound=None,
+        tolerance=1e-14,
+        max_iterations=100_000,
+    )
+    # Coefficients are (numerically) in the null space of the q-th differences,
+    # i.e. a polynomial sequence of degree q - 1 (linear for q = 2).
+    second_diff = np.diff(beta_cd, n=DIFF_ORDER)
+    assert np.max(np.abs(second_diff)) < 1e-6 * (1 + np.max(np.abs(beta)))
+
+
+# ----------------------------------------------------------------------------
+# Phase 3: PSplineTerm
+# ----------------------------------------------------------------------------
+
+
+def _simulate(n, seed=10):
+    rng = np.random.default_rng(seed)
+    x = rng.uniform(0, 1, n)
+    f = np.sin(2 * np.pi * x)
+    y = f + rng.normal(0, 0.2, n)
+    return x[:, None], y, f
+
+
+def test_pspline_term_fit_and_predict():
+    X, y, f = _simulate(500)
+    distribution, fitted_values, sample_weight, estimation_weight = _make_term_inputs(
+        500
+    )
+    term = PSplineTerm(feature=0, n_splines=N_SPLINES)._prepare_term()
+    term = term.fit(
+        X=X,
+        y=y - y.mean(),
+        fitted_values=fitted_values,
+        target_values=y,
+        distribution=distribution,
+        sample_weight=sample_weight,
+        estimation_weight=estimation_weight,
+    )
+    pred = term.predict_out_of_sample(X=X, distribution=distribution)
+    assert pred.shape == (500,)
+    centered_f = f - f.mean()
+    mse = np.mean((pred - centered_f) ** 2)
+    assert mse < 0.05 * np.var(centered_f)
+    # Selection diagnostics (constrained parameterization has K - 1 coefficients)
+    assert term._state.coef_path_.shape == (term.lambda_n, N_SPLINES - 1)
+    assert DIFF_ORDER - 1 - 1e-6 <= term.edf_ <= N_SPLINES - 1 + 1e-6
+    assert term.lambda_selected_ > 0
+
+
+def test_pspline_term_fixed_lambda():
+    X, y, _ = _simulate(300)
+    distribution, fitted_values, sample_weight, estimation_weight = _make_term_inputs(
+        300
+    )
+    term = PSplineTerm(feature=0, n_splines=N_SPLINES, lambda_=10.0)._prepare_term()
+    term = term.fit(
+        X=X,
+        y=y - y.mean(),
+        fitted_values=fitted_values,
+        target_values=y,
+        distribution=distribution,
+        sample_weight=sample_weight,
+        estimation_weight=estimation_weight,
+    )
+    assert term._state.coef_path_.shape == (1, N_SPLINES - 1)
+    assert term.lambda_selected_ == 10.0
+
+
+def test_pspline_term_update_matches_batch_grams():
+    n, n0 = 600, 400
+    X, y, _ = _simulate(n)
+    y = y - y.mean()
+    distribution, fitted_values, sample_weight, estimation_weight = _make_term_inputs(n)
+
+    term = PSplineTerm(feature=0, n_splines=N_SPLINES, forget=0.0)._prepare_term()
+    term = term.fit(
+        X=X[:n0],
+        y=y[:n0],
+        fitted_values=fitted_values[:n0],
+        target_values=y[:n0],
+        distribution=distribution,
+        sample_weight=sample_weight[:n0],
+        estimation_weight=estimation_weight[:n0],
+    )
+    updated = term.update(
+        X=X[n0:],
+        y=y[n0:],
+        fitted_values=fitted_values[n0:],
+        target_values=y[n0:],
+        distribution=distribution,
+        sample_weight=sample_weight[n0:],
+        estimation_weight=estimation_weight[n0:],
+    )
+
+    # Immutability: the original term is unchanged
+    assert updated is not term
+    assert updated._state.n_observations == n
+    assert term._state.n_observations == n0
+
+    # Gram updates are exact: same as batch grams on the full design matrix
+    # built with the *initial* knots and column means.
+    X_mat_full = term.make_design_matrix(X)
+    g_direct = init_gram(X_mat_full, np.ones(n), 0.0)
+    h_direct = init_y_gram(X_mat_full, y, np.ones(n), 0.0)
+    np.testing.assert_allclose(updated._state.g, g_direct, atol=1e-8)
+    np.testing.assert_allclose(updated._state.h, h_direct, atol=1e-8)
+
+    # Selected coefficients solve the penalized normal equations
+    penalty = updated.make_penalty_matrix()
+    beta_direct = np.linalg.solve(
+        g_direct + updated.lambda_selected_ * penalty, h_direct.squeeze(-1)
+    )
+    np.testing.assert_allclose(updated.coef_, beta_direct, atol=1e-4)
+
+
+def test_pspline_term_extrapolates_linearly_out_of_sample():
+    X, y, _ = _simulate(400)
+    distribution, fitted_values, sample_weight, estimation_weight = _make_term_inputs(
+        400
+    )
+    term = PSplineTerm(feature=0, n_splines=N_SPLINES)._prepare_term()
+    term = term.fit(
+        X=X,
+        y=y - y.mean(),
+        fitted_values=fitted_values,
+        target_values=y,
+        distribution=distribution,
+        sample_weight=sample_weight,
+        estimation_weight=estimation_weight,
+    )
+    X_out = np.array([2.0, 2.5, 3.0])[:, None]
+    pred = term.predict_out_of_sample(X=X_out, distribution=distribution)
+    np.testing.assert_allclose(pred[1], (pred[0] + pred[2]) / 2, atol=1e-10)
+
+
+def test_pspline_term_invalid_inputs():
+    with pytest.raises(ValueError):
+        PSplineTerm(feature=0, n_splines=3, degree=3)._prepare_term().fit(
+            X=np.linspace(0, 1, 10)[:, None],
+            y=np.zeros(10),
+            fitted_values=None,
+            target_values=None,
+            distribution=None,
+            sample_weight=np.ones(10),
+            estimation_weight=np.ones(10),
+        )
+    with pytest.raises(ValueError):
+        make_difference_penalty(n_splines=5, diff_order=5)
+    with pytest.raises(ValueError):
+        make_bspline_knots(0.0, 0.0, 10, 3)
+
+
+# ----------------------------------------------------------------------------
+# Phase 4: Integration with the estimator
+# ----------------------------------------------------------------------------
+
+
+def test_integration_structured_additive_regressor():
+    rng = np.random.default_rng(123)
+    n = 800
+    x = rng.uniform(-2, 2, n)
+    mu = np.sin(2 * x)
+    sigma = np.exp(-0.5 + 0.3 * x)
+    y = mu + sigma * rng.normal(size=n)
+    X = x[:, None]
+
+    estimator = OnlineStructuredAdditiveDistributionRegressor(
+        distribution=Normal(),
+        terms={
+            0: [InterceptTerm(), PSplineTerm(feature=0, n_splines=15)],
+            1: [InterceptTerm(), PSplineTerm(feature=0, n_splines=15)],
+        },
+        scale_inputs=True,
+    )
+    estimator.fit(X, y)
+    fitted = estimator.predict(X)
+    assert fitted.shape == (n, 2)
+    assert np.all(np.isfinite(fitted))
+    mse_mu = np.mean((fitted[:, 0] - mu) ** 2)
+    assert mse_mu < 0.1 * np.var(mu)
+
+    # Online update + prediction run cleanly
+    x_new = rng.uniform(-2, 2, 50)
+    y_new = np.sin(2 * x_new) + np.exp(-0.5 + 0.3 * x_new) * rng.normal(size=50)
+    estimator.update(x_new[:, None], y_new)
+    fitted_new = estimator.predict(X)
+    assert np.all(np.isfinite(fitted_new))
+    mse_mu_new = np.mean((fitted_new[:, 0] - mu) ** 2)
+    assert mse_mu_new < 0.1 * np.var(mu)


### PR DESCRIPTION
Implementation complete. All 871 tests pass (14 new), ruff clean. Summary of what was built:

**Phase 1+3 — splines.py** (new)
- `make_bspline_knots` / `make_bspline_basis`: equidistant-knot B-spline basis via `scipy.interpolate.BSpline.design_matrix`, with exact linear extrapolation beyond boundary knots (mgcv `bs="ps"` behavior)
- `make_difference_penalty`: Frobenius-normalized $S = D_q^\top D_q$
- `make_centering_constraint`: sum-to-zero identifiability via QR null space of the weighted basis column means ($K-1$ coefficients, no intercept clash)
- `make_demmler_reinsch_transform`: fixed-at-fit reparameterization giving identity Gramian + diagonal penalty
- Frozen `PSplineTermState` and `PSplineTerm(Term)` with `feature`, `n_splines=20`, `degree=3`, `diff_order=2`, `lambda_=None` (grid selection) or fixed, `ic`, `forget`, `knot_padding=0.05`; immutable `update` returning new instances; `edf_` / `lambda_selected_` diagnostics; EDF-based IC selection using $\mathrm{tr}((G+\lambda S)^{-1}G)$ and `calculate_effective_training_length`

**Phase 2 — solver & method**
- [cd_base.py](src/ondil/coordinate_descent/cd_base.py): numba `online_coordinate_descent_quadratic` (runs CD on $G + \lambda S$, keeps soft-thresholding for L1; reduces bit-for-bit to plain CD when $S=0$) and `online_coordinate_descent_quadratic_path` with `get_start_beta` warm starts
- quadratic_penalty.py: `QuadraticPenaltyPath(EstimationMethod)` — path-based, geometric λ-grid scaled by $\mathrm{tr}(G)/\mathrm{tr}(S)$ or fixed `lambda_`, reuses `init_gram`/`update_gram` with forgetting; registered as `"quadratic_penalty"` in the factory

**Verification — test_terms_pspline.py**: partition of unity, linear extrapolation, penalty annihilates degree-$(q{-}1)$ polynomials + bandedness, CD ≡ direct solve, $S=0$ ≡ plain CD (exact), warm-started path correctness, edf monotone in λ with bounds, large-λ polynomial limit, batch-vs-online Gram exactness, and full estimator integration on heteroskedastic $y \sim N(\sin 2x, e^{-0.5+0.3x})$ including `update`.

One notable deviation from the plan: plain CD on the raw centered basis is too ill-conditioned across the λ-path (descending warm starts hit max-iterations and return wrong solutions). I added the Demmler–Reinsch reparameterization fixed at fit time — Gramian becomes identity, penalty diagonal — so CD converges fast and exactly at every λ, while online Gram updates remain exact since the transform is a fixed linear map of the basis. Docs were added in terms_and_features.md and a runnable example in pspline_terms.py.